### PR TITLE
Add Ggplot legend

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,8 @@ Suggests:
     R.devices,
     usethis,
     rlang,
-    magick
+    magick,
+    cowplot
 Config/testthat/edition: 3
 biocViews: Software, DataRepresentation, Genetics, GraphAndNetwork, Visualization
 BugReports: https://github.com/LouisLeNezet/Pedixplorer/issues

--- a/R/kindepth.R
+++ b/R/kindepth.R
@@ -250,7 +250,7 @@ setMethod("kindepth", "character_OR_integer",
             ## bug: done should be true if dads == bad | moms == bad
         }
         if (all(depth > 0)) {
-            depth_found <- paste0(depth, collapse = ", ")
+            depth_found <- paste0max(depth, max = 10, collapse = ", ")
             if (force == FALSE) {
                 stop(
                     "You found a bug in kindepth's alignment code! ",

--- a/R/ped_to_legdf.R
+++ b/R/ped_to_legdf.R
@@ -65,7 +65,7 @@ setMethod("ped_to_legdf", "Pedigree", function(
         type = character(), fill = character(), border = character(),
         angle = numeric(), density = numeric(), cex = numeric(),
         label = character(), tips = character(), adjx = numeric(),
-        adjy = numeric()
+        adjy = numeric(), lwd = numeric()
     )
     sex_equiv <- c("Male", "Female", "Unknown")
     all_lab <- list(sex_equiv, border(obj)$labels)
@@ -114,7 +114,7 @@ setMethod("ped_to_legdf", "Pedigree", function(
         type = paste(names(poly1)[all_sex], 1, 1, sep = "_"),
         fill = "white",
         border = "black",
-        id = "sex", cex = lwd
+        id = "sex", lwd = lwd
     )
 
     sex_label <- data.frame(
@@ -136,7 +136,7 @@ setMethod("ped_to_legdf", "Pedigree", function(
         type = rep("square_1_1", length(border_mods)),
         border = border(obj)$border[match(border_mods, border(obj)$mods)],
         fill = "white",
-        id = "border", cex = lwd
+        id = "border", lwd = lwd
     )
     lab <- border(obj)$labels[match(border_mods, border(obj)$mods)]
     lab[is.na(lab)] <- "NA"
@@ -161,7 +161,7 @@ setMethod("ped_to_legdf", "Pedigree", function(
             type = rep(paste("square", 1, 1, sep = "_"),
                 length(aff_mods)
             ),
-            border = "black", fill = "white", cex = lwd,
+            border = "black", fill = "white", lwd = lwd,
             id = paste("aff_bkg", aff, aff_mods, sep = "_")
         )
 
@@ -171,7 +171,7 @@ setMethod("ped_to_legdf", "Pedigree", function(
             type = rep(paste("square", n_aff, aff, sep = "_"),
                 length(aff_mods)
             ),
-            border = "black", cex = lwd,
+            border = "black", lwd = lwd,
             fill = aff_df$fill,
             id = paste("affected", aff, aff_mods, sep = "_")
         )

--- a/R/ped_to_plotdf.R
+++ b/R/ped_to_plotdf.R
@@ -123,7 +123,7 @@ setMethod("ped_to_plotdf", "Pedigree", function(
         x0 = numeric(), y0 = numeric(), x1 = numeric(), y1 = numeric(),
         type = character(), fill = character(), border = character(),
         angle = numeric(), density = numeric(), cex = numeric(),
-        label = character(), tips = character(),
+        label = character(), tips = character(), lwd = numeric(),
         adjx = numeric(), adjy = numeric(), lty = numeric()
     )
     plist <- align(

--- a/R/plot_fct.R
+++ b/R/plot_fct.R
@@ -394,12 +394,13 @@ draw_text <- function(x, y, label, ggplot_gen = FALSE,
         }
         data <- data.frame(
             x = x, y = y, label = label,
-            cex = cex, col = col, tips = tips
+            cex = cex, col = col, tips = tips,
+            adjx = adjx, adjy = adjy
         )
         ggplot2::geom_text(
             data = data,
             ggplot2::aes(
-                x = x, y = y, label = label
+                x = x, y = y, label = label, vjust = adjy, hjust = adjx
             ), size = cex / 0.3, colour = col, inherit.aes = FALSE
         )
     }

--- a/R/plot_pedigree.R
+++ b/R/plot_pedigree.R
@@ -169,10 +169,6 @@ setMethod("plot", c(x = "Pedigree", y = "missing"),
         add_to_existing = FALSE,
         label_dist = c(1, 3, 5), label_cex = c(1, 0.7, 1)
     ) {
-        if (legend & ggplot_gen) {
-            stop("Legend with ggplot not yet implemented")
-        }
-
         famlist <- unique(famid(ped(x)))
         if (length(famlist) > 1) {
             message("Multiple families present, only plotting family ",
@@ -223,24 +219,29 @@ setMethod("plot", c(x = "Pedigree", y = "missing"),
             }
             par(leg_par)
 
-            plot_legend(obj = x, cex = leg_cex,
+            lst_leg <- plot_legend(obj = x, cex = leg_cex,
                 boxw = leg_symbolsize,
                 boxh = leg_symbolsize,
                 adjx = leg_adjx, adjy = leg_adjy,
                 leg_loc = leg_loc, add_to_existing = TRUE,
-                usr = leg_usr, lwd = lwd, precision = precision
+                usr = leg_usr, lwd = lwd, precision = precision,
+                ggplot_gen = ggplot_gen
             )
+        } else {
+            lst_leg <- NULL
         }
 
         if (ggplot_gen) {
             invisible(list(
                 df = lst$df, par_usr = lst$par_usr,
-                ggplot = p, ind_not_plot = lst$ind_not_plot
+                ggplot = p, ind_not_plot = lst$ind_not_plot,
+                legend = lst_leg
             ))
         } else {
             invisible(list(
                 df = lst$df, par_usr = lst$par_usr,
-                ind_not_plot = lst$ind_not_plot
+                ind_not_plot = lst$ind_not_plot,
+                legend = lst_leg
             ))
         }
     }

--- a/R/plot_pedigree.R
+++ b/R/plot_pedigree.R
@@ -13,7 +13,7 @@
 plot_legend <- function(
     obj, cex = 1, boxw = 0.1, boxh = 0.1, adjx = 0, adjy = 0,
     leg_loc = c(0, 1, 0, 1), add_to_existing = FALSE, usr = NULL,
-    lwd = 1, precision = 4
+    lwd = 1, precision = 4, ggplot_gen = FALSE
 ) {
     leg <- ped_to_legdf(
         obj, cex = cex,
@@ -38,12 +38,18 @@ plot_legend <- function(
             leg$df[symbol, ]$y0 <- leg$df[symbol, ]$y0 - boxh
         }
     }
-    plot_fromdf(
+
+    p <- plot_fromdf(
         leg$df, add_to_existing = add_to_existing,
-        boxw = boxw, boxh = boxh, usr = usr
+        boxw = boxw, boxh = boxh, usr = usr,
+        ggplot_gen = ggplot_gen
     )
 
-    invisible(list(df = leg$df, par_usr = usr))
+    if (ggplot_gen) {
+        invisible(list(df = leg$df, par_usr = usr, ggplot = p))
+    } else {
+        invisible(list(df = leg$df, par_usr = usr))
+    }
 }
 
 
@@ -163,6 +169,10 @@ setMethod("plot", c(x = "Pedigree", y = "missing"),
         add_to_existing = FALSE,
         label_dist = c(1, 3, 5), label_cex = c(1, 0.7, 1)
     ) {
+        if (legend & ggplot_gen) {
+            stop("Legend with ggplot not yet implemented")
+        }
+
         famlist <- unique(famid(ped(x)))
         if (length(famlist) > 1) {
             message("Multiple families present, only plotting family ",
@@ -212,7 +222,7 @@ setMethod("plot", c(x = "Pedigree", y = "missing"),
                 )
             }
             par(leg_par)
-            graphics::box(col = "#00000000")
+
             plot_legend(obj = x, cex = leg_cex,
                 boxw = leg_symbolsize,
                 boxh = leg_symbolsize,

--- a/man/plot_legend.Rd
+++ b/man/plot_legend.Rd
@@ -15,7 +15,8 @@ plot_legend(
   add_to_existing = FALSE,
   usr = NULL,
   lwd = 1,
-  precision = 4
+  precision = 4,
+  ggplot_gen = FALSE
 )
 }
 \arguments{

--- a/tests/testthat/_snaps/ped_to_legdf.md
+++ b/tests/testthat/_snaps/ped_to_legdf.md
@@ -55,57 +55,57 @@
       48  affected_label_3_6 9.389 8.0000 NA NA        text   black   <NA>    NA
       49             max_lim 0.000 0.0000 NA NA        text    <NA>  black    NA
       50             max_lim 8.389 8.0000 NA NA        text    <NA>  black    NA
-         density cex                         label tips adjx adjy
-      1       NA 1.2                           Sex <NA>    0    1
-      2       NA 1.2                        Border <NA>    0    1
-      3       NA 1.2                     affection <NA>    0    1
-      4       NA 1.2                         avail <NA>    0    1
-      5       NA 1.2                       val_num <NA>    0    1
-      6       NA 1.0                          <NA> <NA>   NA   NA
-      7       NA 1.0                          <NA> <NA>   NA   NA
-      8       NA 1.0                          <NA> <NA>   NA   NA
-      9       NA 0.8                          Male <NA>    0    1
-      10      NA 0.8                        Female <NA>    0    1
-      11      NA 0.8                       Unknown <NA>    0    1
-      12      NA 1.0                          <NA> <NA>   NA   NA
-      13      NA 1.0                          <NA> <NA>   NA   NA
-      14      NA 0.8                 Non Available <NA>    0    1
-      15      NA 0.8                     Available <NA>    0    1
-      16      NA 1.0                          <NA> <NA>   NA   NA
-      17      NA 1.0                          <NA> <NA>   NA   NA
-      18      NA 1.0                          <NA> <NA>   NA   NA
-      19      NA 1.0                          <NA> <NA>   NA   NA
-      20      NA 1.0                          <NA> <NA>   NA   NA
-      21      NA 1.0                          <NA> <NA>   NA   NA
-      22      NA 0.8             Healthy <= to 0.5 <NA>    0    1
-      23      NA 0.8             Affected > to 0.5 <NA>    0    1
-      24      NA 0.8                            NA <NA>    0    1
-      25      NA 1.0                          <NA> <NA>   NA   NA
-      26      NA 1.0                          <NA> <NA>   NA   NA
-      27      NA 1.0                          <NA> <NA>   NA   NA
-      28      NA 1.0                          <NA> <NA>   NA   NA
-      29      NA 0.8             Healthy are FALSE <NA>    0    1
-      30      NA 0.8             Affected are TRUE <NA>    0    1
-      31      NA 1.0                          <NA> <NA>   NA   NA
-      32      NA 1.0                          <NA> <NA>   NA   NA
-      33      NA 1.0                          <NA> <NA>   NA   NA
-      34      NA 1.0                          <NA> <NA>   NA   NA
-      35      NA 1.0                          <NA> <NA>   NA   NA
-      36      NA 1.0                          <NA> <NA>   NA   NA
-      37      NA 1.0                          <NA> <NA>   NA   NA
-      38      NA 1.0                          <NA> <NA>   NA   NA
-      39      NA 1.0                          <NA> <NA>   NA   NA
-      40      NA 1.0                          <NA> <NA>   NA   NA
-      41      NA 1.0                          <NA> <NA>   NA   NA
-      42      NA 1.0                          <NA> <NA>   NA   NA
-      43      NA 0.8 Healthy <= to 115 : [101,106] <NA>    0    1
-      44      NA 0.8 Healthy <= to 115 : (106,110] <NA>    0    1
-      45      NA 0.8 Healthy <= to 115 : (110,115] <NA>    0    1
-      46      NA 0.8 Affected > to 115 : [116,124] <NA>    0    1
-      47      NA 0.8 Affected > to 115 : (124,133] <NA>    0    1
-      48      NA 0.8 Affected > to 115 : (133,141] <NA>    0    1
-      49      NA  NA                          <NA> <NA>    0    1
-      50      NA  NA                          <NA> <NA>    0    1
+         density cex                         label tips adjx adjy lwd
+      1       NA 1.2                           Sex <NA>    0    1  NA
+      2       NA 1.2                        Border <NA>    0    1  NA
+      3       NA 1.2                     affection <NA>    0    1  NA
+      4       NA 1.2                         avail <NA>    0    1  NA
+      5       NA 1.2                       val_num <NA>    0    1  NA
+      6       NA  NA                          <NA> <NA>   NA   NA   1
+      7       NA  NA                          <NA> <NA>   NA   NA   1
+      8       NA  NA                          <NA> <NA>   NA   NA   1
+      9       NA 0.8                          Male <NA>    0    1  NA
+      10      NA 0.8                        Female <NA>    0    1  NA
+      11      NA 0.8                       Unknown <NA>    0    1  NA
+      12      NA  NA                          <NA> <NA>   NA   NA   1
+      13      NA  NA                          <NA> <NA>   NA   NA   1
+      14      NA 0.8                 Non Available <NA>    0    1  NA
+      15      NA 0.8                     Available <NA>    0    1  NA
+      16      NA  NA                          <NA> <NA>   NA   NA   1
+      17      NA  NA                          <NA> <NA>   NA   NA   1
+      18      NA  NA                          <NA> <NA>   NA   NA   1
+      19      NA  NA                          <NA> <NA>   NA   NA   1
+      20      NA  NA                          <NA> <NA>   NA   NA   1
+      21      NA  NA                          <NA> <NA>   NA   NA   1
+      22      NA 0.8             Healthy <= to 0.5 <NA>    0    1  NA
+      23      NA 0.8             Affected > to 0.5 <NA>    0    1  NA
+      24      NA 0.8                            NA <NA>    0    1  NA
+      25      NA  NA                          <NA> <NA>   NA   NA   1
+      26      NA  NA                          <NA> <NA>   NA   NA   1
+      27      NA  NA                          <NA> <NA>   NA   NA   1
+      28      NA  NA                          <NA> <NA>   NA   NA   1
+      29      NA 0.8             Healthy are FALSE <NA>    0    1  NA
+      30      NA 0.8             Affected are TRUE <NA>    0    1  NA
+      31      NA  NA                          <NA> <NA>   NA   NA   1
+      32      NA  NA                          <NA> <NA>   NA   NA   1
+      33      NA  NA                          <NA> <NA>   NA   NA   1
+      34      NA  NA                          <NA> <NA>   NA   NA   1
+      35      NA  NA                          <NA> <NA>   NA   NA   1
+      36      NA  NA                          <NA> <NA>   NA   NA   1
+      37      NA  NA                          <NA> <NA>   NA   NA   1
+      38      NA  NA                          <NA> <NA>   NA   NA   1
+      39      NA  NA                          <NA> <NA>   NA   NA   1
+      40      NA  NA                          <NA> <NA>   NA   NA   1
+      41      NA  NA                          <NA> <NA>   NA   NA   1
+      42      NA  NA                          <NA> <NA>   NA   NA   1
+      43      NA 0.8 Healthy <= to 115 : [101,106] <NA>    0    1  NA
+      44      NA 0.8 Healthy <= to 115 : (106,110] <NA>    0    1  NA
+      45      NA 0.8 Healthy <= to 115 : (110,115] <NA>    0    1  NA
+      46      NA 0.8 Affected > to 115 : [116,124] <NA>    0    1  NA
+      47      NA 0.8 Affected > to 115 : (124,133] <NA>    0    1  NA
+      48      NA 0.8 Affected > to 115 : (133,141] <NA>    0    1  NA
+      49      NA  NA                          <NA> <NA>    0    1  NA
+      50      NA  NA                          <NA> <NA>    0    1  NA
       
       $par_usr
       $par_usr$boxh

--- a/tests/testthat/_snaps/plot.md
+++ b/tests/testthat/_snaps/plot.md
@@ -170,89 +170,89 @@
       80   <NA>    NA      NA  NA  <NA>
       81   <NA>    NA      NA  NA  <NA>
       82   <NA>    NA      NA  NA  <NA>
-                                                        tips adjx adjy   lty lwd
-      1   <span style='font-size:14px'><b>1_1</b></span><br>   NA   NA  <NA>   1
-      2   <span style='font-size:14px'><b>1_3</b></span><br>   NA   NA  <NA>   1
-      3   <span style='font-size:14px'><b>1_7</b></span><br>   NA   NA  <NA>   1
-      4  <span style='font-size:14px'><b>1_10</b></span><br>   NA   NA  <NA>   1
-      5   <span style='font-size:14px'><b>1_2</b></span><br>   NA   NA  <NA>   1
-      6   <span style='font-size:14px'><b>1_5</b></span><br>   NA   NA  <NA>   1
-      7   <span style='font-size:14px'><b>1_8</b></span><br>   NA   NA  <NA>   1
-      8   <span style='font-size:14px'><b>1_6</b></span><br>   NA   NA  <NA>   1
-      9   <span style='font-size:14px'><b>1_9</b></span><br>   NA   NA  <NA>   1
-      10  <span style='font-size:14px'><b>1_4</b></span><br>   NA   NA  <NA>   1
-      11  <span style='font-size:14px'><b>1_1</b></span><br>  0.5  0.5  <NA>  NA
-      12  <span style='font-size:14px'><b>1_3</b></span><br>  0.5  0.5  <NA>  NA
-      13  <span style='font-size:14px'><b>1_7</b></span><br>  0.5  0.5  <NA>  NA
-      14 <span style='font-size:14px'><b>1_10</b></span><br>  0.5  0.5  <NA>  NA
-      15  <span style='font-size:14px'><b>1_2</b></span><br>  0.5  0.5  <NA>  NA
-      16  <span style='font-size:14px'><b>1_5</b></span><br>  0.5  0.5  <NA>  NA
-      17  <span style='font-size:14px'><b>1_8</b></span><br>  0.5  0.5  <NA>  NA
-      18  <span style='font-size:14px'><b>1_6</b></span><br>  0.5  0.5  <NA>  NA
-      19  <span style='font-size:14px'><b>1_9</b></span><br>  0.5  0.5  <NA>  NA
-      20  <span style='font-size:14px'><b>1_4</b></span><br>  0.5  0.5  <NA>  NA
-      21  <span style='font-size:14px'><b>1_1</b></span><br>   NA   NA  <NA>   1
-      22  <span style='font-size:14px'><b>1_3</b></span><br>   NA   NA  <NA>   1
-      23  <span style='font-size:14px'><b>1_7</b></span><br>   NA   NA  <NA>   1
-      24 <span style='font-size:14px'><b>1_10</b></span><br>   NA   NA  <NA>   1
-      25  <span style='font-size:14px'><b>1_2</b></span><br>   NA   NA  <NA>   1
-      26  <span style='font-size:14px'><b>1_5</b></span><br>   NA   NA  <NA>   1
-      27  <span style='font-size:14px'><b>1_8</b></span><br>   NA   NA  <NA>   1
-      28  <span style='font-size:14px'><b>1_6</b></span><br>   NA   NA  <NA>   1
-      29  <span style='font-size:14px'><b>1_9</b></span><br>   NA   NA  <NA>   1
-      30  <span style='font-size:14px'><b>1_4</b></span><br>   NA   NA  <NA>   1
-      31  <span style='font-size:14px'><b>1_1</b></span><br>  0.5  0.5  <NA>  NA
-      32  <span style='font-size:14px'><b>1_3</b></span><br>  0.5  0.5  <NA>  NA
-      33  <span style='font-size:14px'><b>1_7</b></span><br>  0.5  0.5  <NA>  NA
-      34 <span style='font-size:14px'><b>1_10</b></span><br>  0.5  0.5  <NA>  NA
-      35  <span style='font-size:14px'><b>1_2</b></span><br>  0.5  0.5  <NA>  NA
-      36  <span style='font-size:14px'><b>1_5</b></span><br>  0.5  0.5  <NA>  NA
-      37  <span style='font-size:14px'><b>1_8</b></span><br>  0.5  0.5  <NA>  NA
-      38  <span style='font-size:14px'><b>1_6</b></span><br>  0.5  0.5  <NA>  NA
-      39  <span style='font-size:14px'><b>1_9</b></span><br>  0.5  0.5  <NA>  NA
-      40  <span style='font-size:14px'><b>1_4</b></span><br>  0.5  0.5  <NA>  NA
-      41                                                <NA>   NA   NA solid   1
-      42                                                <NA>   NA   NA solid   1
-      43                                                <NA>   NA   NA solid   1
-      44                                                <NA>   NA   NA solid   1
-      45  <span style='font-size:14px'><b>1_1</b></span><br>  0.5  1.0  <NA>  NA
-      46  <span style='font-size:14px'><b>1_3</b></span><br>  0.5  1.0  <NA>  NA
-      47  <span style='font-size:14px'><b>1_7</b></span><br>  0.5  1.0  <NA>  NA
-      48 <span style='font-size:14px'><b>1_10</b></span><br>  0.5  1.0  <NA>  NA
-      49  <span style='font-size:14px'><b>1_2</b></span><br>  0.5  1.0  <NA>  NA
-      50  <span style='font-size:14px'><b>1_5</b></span><br>  0.5  1.0  <NA>  NA
-      51  <span style='font-size:14px'><b>1_8</b></span><br>  0.5  1.0  <NA>  NA
-      52  <span style='font-size:14px'><b>1_6</b></span><br>  0.5  1.0  <NA>  NA
-      53  <span style='font-size:14px'><b>1_9</b></span><br>  0.5  1.0  <NA>  NA
-      54  <span style='font-size:14px'><b>1_4</b></span><br>  0.5  1.0  <NA>  NA
-      55                                                <NA>   NA   NA solid   1
-      56                                                <NA>   NA   NA solid   1
-      57                                                <NA>   NA   NA solid   1
-      58                                                <NA>   NA   NA solid   1
-      59                                                <NA>   NA   NA solid   1
-      60                                                <NA>   NA   NA solid   1
-      61                                                <NA>   NA   NA solid   1
-      62                                                <NA>   NA   NA solid   1
-      63                                                <NA>   NA   NA solid   1
-      64                                                <NA>   NA   NA solid   1
-      65                                                <NA>   NA   NA solid   1
-      66                                                <NA>   NA   NA solid   1
-      67                                                <NA>   NA   NA solid   1
-      68                                                <NA>   NA   NA solid   1
-      69                                                <NA>   NA   NA solid   1
-      70                                                <NA>   NA   NA solid   1
-      71                                                <NA>   NA   NA solid   1
-      72                                                <NA>   NA   NA solid   1
-      73                                                <NA>  0.5  0.5  <NA>  NA
-      74                                                <NA>   NA   NA solid   1
-      75                                                <NA>   NA   NA solid   1
-      76                                                <NA>   NA   NA solid   1
-      77                                                <NA>   NA   NA solid   1
-      78                                                <NA>   NA   NA solid   1
-      79                                                <NA>   NA   NA solid   1
-      80                                                <NA>   NA   NA solid   1
-      81                                                <NA>   NA   NA solid   1
-      82                                                <NA>   NA   NA solid   1
+                                                        tips lwd adjx adjy   lty
+      1   <span style='font-size:14px'><b>1_1</b></span><br>   1   NA   NA  <NA>
+      2   <span style='font-size:14px'><b>1_3</b></span><br>   1   NA   NA  <NA>
+      3   <span style='font-size:14px'><b>1_7</b></span><br>   1   NA   NA  <NA>
+      4  <span style='font-size:14px'><b>1_10</b></span><br>   1   NA   NA  <NA>
+      5   <span style='font-size:14px'><b>1_2</b></span><br>   1   NA   NA  <NA>
+      6   <span style='font-size:14px'><b>1_5</b></span><br>   1   NA   NA  <NA>
+      7   <span style='font-size:14px'><b>1_8</b></span><br>   1   NA   NA  <NA>
+      8   <span style='font-size:14px'><b>1_6</b></span><br>   1   NA   NA  <NA>
+      9   <span style='font-size:14px'><b>1_9</b></span><br>   1   NA   NA  <NA>
+      10  <span style='font-size:14px'><b>1_4</b></span><br>   1   NA   NA  <NA>
+      11  <span style='font-size:14px'><b>1_1</b></span><br>  NA  0.5  0.5  <NA>
+      12  <span style='font-size:14px'><b>1_3</b></span><br>  NA  0.5  0.5  <NA>
+      13  <span style='font-size:14px'><b>1_7</b></span><br>  NA  0.5  0.5  <NA>
+      14 <span style='font-size:14px'><b>1_10</b></span><br>  NA  0.5  0.5  <NA>
+      15  <span style='font-size:14px'><b>1_2</b></span><br>  NA  0.5  0.5  <NA>
+      16  <span style='font-size:14px'><b>1_5</b></span><br>  NA  0.5  0.5  <NA>
+      17  <span style='font-size:14px'><b>1_8</b></span><br>  NA  0.5  0.5  <NA>
+      18  <span style='font-size:14px'><b>1_6</b></span><br>  NA  0.5  0.5  <NA>
+      19  <span style='font-size:14px'><b>1_9</b></span><br>  NA  0.5  0.5  <NA>
+      20  <span style='font-size:14px'><b>1_4</b></span><br>  NA  0.5  0.5  <NA>
+      21  <span style='font-size:14px'><b>1_1</b></span><br>   1   NA   NA  <NA>
+      22  <span style='font-size:14px'><b>1_3</b></span><br>   1   NA   NA  <NA>
+      23  <span style='font-size:14px'><b>1_7</b></span><br>   1   NA   NA  <NA>
+      24 <span style='font-size:14px'><b>1_10</b></span><br>   1   NA   NA  <NA>
+      25  <span style='font-size:14px'><b>1_2</b></span><br>   1   NA   NA  <NA>
+      26  <span style='font-size:14px'><b>1_5</b></span><br>   1   NA   NA  <NA>
+      27  <span style='font-size:14px'><b>1_8</b></span><br>   1   NA   NA  <NA>
+      28  <span style='font-size:14px'><b>1_6</b></span><br>   1   NA   NA  <NA>
+      29  <span style='font-size:14px'><b>1_9</b></span><br>   1   NA   NA  <NA>
+      30  <span style='font-size:14px'><b>1_4</b></span><br>   1   NA   NA  <NA>
+      31  <span style='font-size:14px'><b>1_1</b></span><br>  NA  0.5  0.5  <NA>
+      32  <span style='font-size:14px'><b>1_3</b></span><br>  NA  0.5  0.5  <NA>
+      33  <span style='font-size:14px'><b>1_7</b></span><br>  NA  0.5  0.5  <NA>
+      34 <span style='font-size:14px'><b>1_10</b></span><br>  NA  0.5  0.5  <NA>
+      35  <span style='font-size:14px'><b>1_2</b></span><br>  NA  0.5  0.5  <NA>
+      36  <span style='font-size:14px'><b>1_5</b></span><br>  NA  0.5  0.5  <NA>
+      37  <span style='font-size:14px'><b>1_8</b></span><br>  NA  0.5  0.5  <NA>
+      38  <span style='font-size:14px'><b>1_6</b></span><br>  NA  0.5  0.5  <NA>
+      39  <span style='font-size:14px'><b>1_9</b></span><br>  NA  0.5  0.5  <NA>
+      40  <span style='font-size:14px'><b>1_4</b></span><br>  NA  0.5  0.5  <NA>
+      41                                                <NA>   1   NA   NA solid
+      42                                                <NA>   1   NA   NA solid
+      43                                                <NA>   1   NA   NA solid
+      44                                                <NA>   1   NA   NA solid
+      45  <span style='font-size:14px'><b>1_1</b></span><br>  NA  0.5  1.0  <NA>
+      46  <span style='font-size:14px'><b>1_3</b></span><br>  NA  0.5  1.0  <NA>
+      47  <span style='font-size:14px'><b>1_7</b></span><br>  NA  0.5  1.0  <NA>
+      48 <span style='font-size:14px'><b>1_10</b></span><br>  NA  0.5  1.0  <NA>
+      49  <span style='font-size:14px'><b>1_2</b></span><br>  NA  0.5  1.0  <NA>
+      50  <span style='font-size:14px'><b>1_5</b></span><br>  NA  0.5  1.0  <NA>
+      51  <span style='font-size:14px'><b>1_8</b></span><br>  NA  0.5  1.0  <NA>
+      52  <span style='font-size:14px'><b>1_6</b></span><br>  NA  0.5  1.0  <NA>
+      53  <span style='font-size:14px'><b>1_9</b></span><br>  NA  0.5  1.0  <NA>
+      54  <span style='font-size:14px'><b>1_4</b></span><br>  NA  0.5  1.0  <NA>
+      55                                                <NA>   1   NA   NA solid
+      56                                                <NA>   1   NA   NA solid
+      57                                                <NA>   1   NA   NA solid
+      58                                                <NA>   1   NA   NA solid
+      59                                                <NA>   1   NA   NA solid
+      60                                                <NA>   1   NA   NA solid
+      61                                                <NA>   1   NA   NA solid
+      62                                                <NA>   1   NA   NA solid
+      63                                                <NA>   1   NA   NA solid
+      64                                                <NA>   1   NA   NA solid
+      65                                                <NA>   1   NA   NA solid
+      66                                                <NA>   1   NA   NA solid
+      67                                                <NA>   1   NA   NA solid
+      68                                                <NA>   1   NA   NA solid
+      69                                                <NA>   1   NA   NA solid
+      70                                                <NA>   1   NA   NA solid
+      71                                                <NA>   1   NA   NA solid
+      72                                                <NA>   1   NA   NA solid
+      73                                                <NA>  NA  0.5  0.5  <NA>
+      74                                                <NA>   1   NA   NA solid
+      75                                                <NA>   1   NA   NA solid
+      76                                                <NA>   1   NA   NA solid
+      77                                                <NA>   1   NA   NA solid
+      78                                                <NA>   1   NA   NA solid
+      79                                                <NA>   1   NA   NA solid
+      80                                                <NA>   1   NA   NA solid
+      81                                                <NA>   1   NA   NA solid
+      82                                                <NA>   1   NA   NA solid
       
       $par_usr
       $par_usr$usr

--- a/tests/testthat/_snaps/plot/ped-2-affections-ggplot.svg
+++ b/tests/testthat/_snaps/plot/ped-2-affections-ggplot.svg
@@ -21,95 +21,95 @@
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
 </g>
 <defs>
-  <clipPath id='cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw'>
-    <rect x='0.00' y='17.30' width='720.00' height='558.70' />
+  <clipPath id='cpMi43NHw3MjAuMDB8MTcuMzB8NTczLjI2'>
+    <rect x='2.74' y='17.30' width='717.26' height='555.96' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8MTcuMzB8NTc2LjAw)'>
-<rect x='0.00' y='17.30' width='720.00' height='558.70' style='stroke-width: 1.07; stroke: none;' />
-<line x1='263.96' y1='50.97' x2='457.82' y2='50.97' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='52.36' y1='211.32' x2='246.14' y2='211.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='202.02' y1='371.66' x2='395.81' y2='371.66' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='475.60' y1='211.32' x2='669.46' y2='211.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='202.02' y1='373.10' x2='395.81' y2='373.10' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='43.44' y1='204.42' x2='43.44' y2='183.58' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='678.35' y1='204.42' x2='678.35' y2='183.58' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='43.44' y1='183.58' x2='678.35' y2='183.58' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='360.89' y1='183.58' x2='360.89' y2='143.81' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='360.89' y1='143.81' x2='360.89' y2='90.74' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='360.89' y1='90.74' x2='360.89' y2='50.97' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='193.08' y1='364.77' x2='193.08' y2='343.92' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='193.08' y1='343.92' x2='193.08' y2='343.92' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='193.08' y1='343.92' x2='193.08' y2='304.16' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='193.08' y1='304.16' x2='149.25' y2='251.08' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='149.25' y1='251.08' x2='149.25' y2='211.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='404.70' y1='364.77' x2='510.52' y2='343.92' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='616.34' y1='364.77' x2='510.52' y2='343.92' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='510.52' y1='343.92' x2='510.52' y2='343.92' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='510.52' y1='343.92' x2='510.52' y2='304.16' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='510.52' y1='304.16' x2='572.53' y2='251.08' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='572.53' y1='251.08' x2='572.53' y2='211.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='298.88' y1='525.11' x2='298.88' y2='504.27' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='298.88' y1='504.27' x2='298.88' y2='504.27' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='298.88' y1='504.27' x2='298.88' y2='464.50' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='298.88' y1='464.50' x2='298.88' y2='411.43' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='298.88' y1='411.43' x2='298.88' y2='371.66' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<polygon points='255.07,51.01 255.07,57.95 246.15,57.95 246.15,44.08 255.07,44.08 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FF0000;' />
-<polygon points='43.44,211.36 43.44,218.29 34.51,218.29 34.51,204.42 43.44,204.42 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='193.08,371.70 193.08,378.63 191.92,378.57 190.77,378.40 189.67,378.11 188.62,377.71 187.65,377.20 186.77,376.60 186.00,375.92 185.36,375.17 184.84,374.35 184.46,373.49 184.24,372.61 184.16,371.70 184.24,370.80 184.46,369.91 184.84,369.05 185.36,368.23 186.00,367.48 186.77,366.80 187.65,366.20 188.62,365.70 189.67,365.29 190.77,365.00 191.92,364.83 193.08,364.77 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='298.88,532.04 298.88,538.98 297.72,538.92 296.57,538.74 295.47,538.45 294.42,538.05 293.45,537.55 292.57,536.95 291.80,536.27 291.15,535.51 290.64,534.70 290.26,533.84 290.03,532.95 289.96,532.04 290.03,531.14 290.26,530.25 290.64,529.39 291.15,528.58 291.80,527.82 292.57,527.14 293.45,526.54 294.42,526.04 295.47,525.64 296.57,525.35 297.72,525.17 298.88,525.11 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='466.71,51.01 466.71,57.95 465.55,57.89 464.40,57.71 463.30,57.42 462.25,57.02 461.28,56.51 460.40,55.92 459.63,55.23 458.98,54.48 458.47,53.67 458.09,52.81 457.86,51.92 457.79,51.01 457.86,50.11 458.09,49.22 458.47,48.36 458.98,47.55 459.63,46.79 460.40,46.11 461.28,45.51 462.25,45.01 463.30,44.61 464.40,44.31 465.55,44.14 466.71,44.08 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='255.07,211.36 255.07,218.29 253.91,218.23 252.76,218.05 251.66,217.76 250.61,217.36 249.64,216.86 248.76,216.26 247.99,215.58 247.34,214.82 246.83,214.01 246.45,213.15 246.23,212.26 246.15,211.36 246.23,210.45 246.45,209.56 246.83,208.70 247.34,207.89 247.99,207.14 248.76,206.45 249.64,205.86 250.61,205.35 251.66,204.95 252.76,204.66 253.91,204.48 255.07,204.42 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FF0000;' />
-<polygon points='404.70,371.70 404.70,378.63 395.78,378.63 395.78,364.77 404.70,364.77 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FF0000;' />
-<polygon points='466.71,211.36 466.71,218.29 457.79,218.29 457.79,204.42 466.71,204.42 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='616.34,371.70 616.34,378.63 607.41,378.63 607.41,364.77 616.34,364.77 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='678.35,211.36 678.35,218.29 677.18,218.23 676.04,218.05 674.93,217.76 673.89,217.36 672.91,216.86 672.04,216.26 671.27,215.58 670.62,214.82 670.10,214.01 669.73,213.15 669.50,212.26 669.42,211.36 669.50,210.45 669.73,209.56 670.10,208.70 670.62,207.89 671.27,207.14 672.04,206.45 672.91,205.86 673.89,205.35 674.93,204.95 676.04,204.66 677.18,204.48 678.35,204.42 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FF0000;' />
-<polygon points='255.07,51.01 255.07,44.08 264.00,44.08 264.00,57.95 255.07,57.95 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='43.44,211.36 43.44,204.42 52.36,204.42 52.36,218.29 43.44,218.29 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='193.08,371.70 193.08,364.77 194.25,364.83 195.39,365.00 196.50,365.29 197.55,365.70 198.52,366.20 199.40,366.80 200.17,367.48 200.81,368.23 201.33,369.05 201.71,369.91 201.93,370.80 202.01,371.70 201.93,372.61 201.71,373.49 201.33,374.35 200.81,375.17 200.17,375.92 199.40,376.60 198.52,377.20 197.55,377.71 196.50,378.11 195.39,378.40 194.25,378.57 193.08,378.63 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #C300FF;' />
-<polygon points='298.88,532.04 298.88,525.11 300.05,525.17 301.19,525.35 302.30,525.64 303.34,526.04 304.32,526.54 305.19,527.14 305.96,527.82 306.61,528.58 307.13,529.39 307.50,530.25 307.73,531.14 307.81,532.04 307.73,532.95 307.50,533.84 307.13,534.70 306.61,535.51 305.96,536.27 305.19,536.95 304.32,537.55 303.34,538.05 302.30,538.45 301.19,538.74 300.05,538.92 298.88,538.98 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='466.71,51.01 466.71,44.08 467.88,44.14 469.02,44.31 470.13,44.61 471.17,45.01 472.14,45.51 473.02,46.11 473.79,46.79 474.44,47.55 474.96,48.36 475.33,49.22 475.56,50.11 475.64,51.01 475.56,51.92 475.33,52.81 474.96,53.67 474.44,54.48 473.79,55.23 473.02,55.92 472.14,56.51 471.17,57.02 470.13,57.42 469.02,57.71 467.88,57.89 466.71,57.95 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #BEBEBE;' />
-<polygon points='255.07,211.36 255.07,204.42 256.24,204.48 257.38,204.66 258.49,204.95 259.54,205.35 260.51,205.86 261.38,206.45 262.15,207.14 262.80,207.89 263.32,208.70 263.69,209.56 263.92,210.45 264.00,211.36 263.92,212.26 263.69,213.15 263.32,214.01 262.80,214.82 262.15,215.58 261.38,216.26 260.51,216.86 259.54,217.36 258.49,217.76 257.38,218.05 256.24,218.23 255.07,218.29 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #C300FF;' />
-<polygon points='404.70,371.70 404.70,364.77 413.63,364.77 413.63,378.63 404.70,378.63 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='466.71,211.36 466.71,204.42 475.64,204.42 475.64,218.29 466.71,218.29 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #C300FF;' />
-<polygon points='616.34,371.70 616.34,364.77 625.26,364.77 625.26,378.63 616.34,378.63 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='678.35,211.36 678.35,204.42 679.51,204.48 680.66,204.66 681.76,204.95 682.81,205.35 683.78,205.86 684.66,206.45 685.43,207.14 686.08,207.89 686.59,208.70 686.97,209.56 687.20,210.45 687.27,211.36 687.20,212.26 686.97,213.15 686.59,214.01 686.08,214.82 685.43,215.58 684.66,216.26 683.78,216.86 682.81,217.36 681.76,217.76 680.66,218.05 679.51,218.23 678.35,218.29 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
-<line x1='244.36' y1='59.31' x2='265.87' y2='42.70' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='32.73' y1='219.65' x2='54.14' y2='202.98' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='455.92' y1='59.31' x2='477.50' y2='42.70' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='244.36' y1='219.65' x2='265.87' y2='202.98' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<text x='250.61' y='54.24' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='38.97' y='214.58' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='188.62' y='374.92' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='294.44' y='535.27' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='462.27' y='54.24' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='250.61' y='214.58' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='400.26' y='374.92' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='462.27' y='214.58' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='611.89' y='374.92' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='673.90' y='214.58' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='259.52' y='54.24' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='47.90' y='214.58' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='197.55' y='374.92' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='303.33' y='535.27' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='259.52' y='214.58' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='409.15' y='374.92' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='471.16' y='214.58' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='620.78' y='374.92' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='682.79' y='214.58' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='510.52' y='357.61' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>?</text>
-<text x='255.07' y='72.84' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_1</text>
-<text x='43.44' y='233.18' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_3</text>
-<text x='193.08' y='393.52' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_7</text>
-<text x='298.88' y='553.87' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='21.10px' lengthAdjust='spacingAndGlyphs'>1_10</text>
-<text x='466.71' y='72.84' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_2</text>
-<text x='255.07' y='233.18' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_5</text>
-<text x='404.70' y='393.52' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_8</text>
-<text x='466.71' y='233.18' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_6</text>
-<text x='616.34' y='393.52' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_9</text>
-<text x='678.35' y='233.18' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_4</text>
+<g clip-path='url(#cpMi43NHw3MjAuMDB8MTcuMzB8NTczLjI2)'>
+<rect x='2.74' y='17.30' width='717.26' height='555.96' style='stroke-width: 1.07; stroke: none;' />
+<line x1='265.70' y1='50.81' x2='458.82' y2='50.81' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='54.90' y1='210.37' x2='247.95' y2='210.37' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='203.99' y1='369.92' x2='397.05' y2='369.92' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='476.53' y1='210.37' x2='669.65' y2='210.37' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='203.99' y1='371.36' x2='397.05' y2='371.36' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='46.01' y1='203.50' x2='46.01' y2='182.76' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='678.51' y1='203.50' x2='678.51' y2='182.76' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='46.01' y1='182.76' x2='678.51' y2='182.76' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='362.26' y1='182.76' x2='362.26' y2='143.19' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='362.26' y1='143.19' x2='362.26' y2='90.38' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='362.26' y1='90.38' x2='362.26' y2='50.81' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='195.09' y1='363.06' x2='195.09' y2='342.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='195.09' y1='342.32' x2='195.09' y2='342.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='195.09' y1='342.32' x2='195.09' y2='302.75' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='195.09' y1='302.75' x2='151.43' y2='249.94' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='151.43' y1='249.94' x2='151.43' y2='210.37' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='405.90' y1='363.06' x2='511.32' y2='342.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='616.73' y1='363.06' x2='511.32' y2='342.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='511.32' y1='342.32' x2='511.32' y2='342.32' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='511.32' y1='342.32' x2='511.32' y2='302.75' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='511.32' y1='302.75' x2='573.09' y2='249.94' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='573.09' y1='249.94' x2='573.09' y2='210.37' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='300.48' y1='522.62' x2='300.48' y2='501.88' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='300.48' y1='501.88' x2='300.48' y2='501.88' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='300.48' y1='501.88' x2='300.48' y2='462.31' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='300.48' y1='462.31' x2='300.48' y2='409.49' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='300.48' y1='409.49' x2='300.48' y2='369.92' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<polygon points='256.84,50.85 256.84,57.75 247.95,57.75 247.95,43.95 256.84,43.95 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FF0000;' />
+<polygon points='46.01,210.40 46.01,217.30 37.12,217.30 37.12,203.50 46.01,203.50 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='195.09,369.96 195.09,376.86 193.93,376.80 192.79,376.63 191.69,376.34 190.64,375.94 189.68,375.44 188.80,374.84 188.04,374.16 187.39,373.41 186.88,372.60 186.50,371.75 186.28,370.86 186.20,369.96 186.28,369.06 186.50,368.18 186.88,367.32 187.39,366.51 188.04,365.76 188.80,365.08 189.68,364.49 190.64,363.99 191.69,363.59 192.79,363.30 193.93,363.12 195.09,363.06 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='300.48,529.52 300.48,536.42 299.32,536.36 298.18,536.18 297.08,535.89 296.04,535.50 295.07,534.99 294.20,534.40 293.43,533.72 292.79,532.97 292.27,532.16 291.90,531.31 291.67,530.42 291.59,529.52 291.67,528.62 291.90,527.73 292.27,526.88 292.79,526.07 293.43,525.32 294.20,524.64 295.07,524.05 296.04,523.54 297.08,523.15 298.18,522.85 299.32,522.68 300.48,522.62 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='467.67,50.85 467.67,57.75 466.51,57.69 465.37,57.51 464.27,57.22 463.23,56.82 462.26,56.32 461.39,55.73 460.62,55.05 459.97,54.30 459.46,53.49 459.09,52.63 458.86,51.75 458.78,50.85 458.86,49.95 459.09,49.06 459.46,48.21 459.97,47.40 460.62,46.65 461.39,45.97 462.26,45.37 463.23,44.87 464.27,44.47 465.37,44.18 466.51,44.01 467.67,43.95 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='256.84,210.40 256.84,217.30 255.68,217.25 254.54,217.07 253.44,216.78 252.40,216.38 251.43,215.88 250.56,215.28 249.79,214.61 249.14,213.85 248.63,213.05 248.25,212.19 248.03,211.31 247.95,210.40 248.03,209.50 248.25,208.62 248.63,207.76 249.14,206.95 249.79,206.20 250.56,205.53 251.43,204.93 252.40,204.43 253.44,204.03 254.54,203.74 255.68,203.56 256.84,203.50 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FF0000;' />
+<polygon points='405.90,369.96 405.90,376.86 397.01,376.86 397.01,363.06 405.90,363.06 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FF0000;' />
+<polygon points='467.67,210.40 467.67,217.30 458.78,217.30 458.78,203.50 467.67,203.50 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='616.73,369.96 616.73,376.86 607.84,376.86 607.84,363.06 616.73,363.06 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='678.51,210.40 678.51,217.30 677.35,217.25 676.21,217.07 675.10,216.78 674.06,216.38 673.09,215.88 672.22,215.28 671.45,214.61 670.81,213.85 670.29,213.05 669.92,212.19 669.69,211.31 669.62,210.40 669.69,209.50 669.92,208.62 670.29,207.76 670.81,206.95 671.45,206.20 672.22,205.53 673.09,204.93 674.06,204.43 675.10,204.03 676.21,203.74 677.35,203.56 678.51,203.50 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FF0000;' />
+<polygon points='256.84,50.85 256.84,43.95 265.73,43.95 265.73,57.75 256.84,57.75 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='46.01,210.40 46.01,203.50 54.90,203.50 54.90,217.30 46.01,217.30 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='195.09,369.96 195.09,363.06 196.25,363.12 197.39,363.30 198.49,363.59 199.54,363.99 200.50,364.49 201.38,365.08 202.14,365.76 202.79,366.51 203.30,367.32 203.68,368.18 203.90,369.06 203.98,369.96 203.90,370.86 203.68,371.75 203.30,372.60 202.79,373.41 202.14,374.16 201.38,374.84 200.50,375.44 199.54,375.94 198.49,376.34 197.39,376.63 196.25,376.80 195.09,376.86 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #C300FF;' />
+<polygon points='300.48,529.52 300.48,522.62 301.65,522.68 302.79,522.85 303.89,523.15 304.93,523.54 305.90,524.05 306.77,524.64 307.54,525.32 308.18,526.07 308.70,526.88 309.07,527.73 309.30,528.62 309.38,529.52 309.30,530.42 309.07,531.31 308.70,532.16 308.18,532.97 307.54,533.72 306.77,534.40 305.90,534.99 304.93,535.50 303.89,535.89 302.79,536.18 301.65,536.36 300.48,536.42 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='467.67,50.85 467.67,43.95 468.83,44.01 469.98,44.18 471.08,44.47 472.12,44.87 473.09,45.37 473.96,45.97 474.73,46.65 475.37,47.40 475.89,48.21 476.26,49.06 476.49,49.95 476.57,50.85 476.49,51.75 476.26,52.63 475.89,53.49 475.37,54.30 474.73,55.05 473.96,55.73 473.09,56.32 472.12,56.82 471.08,57.22 469.98,57.51 468.83,57.69 467.67,57.75 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #BEBEBE;' />
+<polygon points='256.84,210.40 256.84,203.50 258.00,203.56 259.14,203.74 260.24,204.03 261.29,204.43 262.25,204.93 263.13,205.53 263.90,206.20 264.54,206.95 265.06,207.76 265.43,208.62 265.66,209.50 265.73,210.40 265.66,211.31 265.43,212.19 265.06,213.05 264.54,213.85 263.90,214.61 263.13,215.28 262.25,215.88 261.29,216.38 260.24,216.78 259.14,217.07 258.00,217.25 256.84,217.30 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #C300FF;' />
+<polygon points='405.90,369.96 405.90,363.06 414.79,363.06 414.79,376.86 405.90,376.86 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='467.67,210.40 467.67,203.50 476.57,203.50 476.57,217.30 467.67,217.30 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #C300FF;' />
+<polygon points='616.73,369.96 616.73,363.06 625.62,363.06 625.62,376.86 616.73,376.86 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='678.51,210.40 678.51,203.50 679.67,203.56 680.81,203.74 681.91,204.03 682.95,204.43 683.92,204.93 684.79,205.53 685.56,206.20 686.21,206.95 686.72,207.76 687.09,208.62 687.32,209.50 687.40,210.40 687.32,211.31 687.09,212.19 686.72,213.05 686.21,213.85 685.56,214.61 684.79,215.28 683.92,215.88 682.95,216.38 681.91,216.78 680.81,217.07 679.67,217.25 678.51,217.30 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
+<line x1='246.17' y1='59.10' x2='267.59' y2='42.57' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='35.34' y1='218.66' x2='56.68' y2='202.07' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='456.92' y1='59.10' x2='478.43' y2='42.57' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='246.17' y1='218.66' x2='267.59' y2='202.07' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='252.39' y='54.07' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='41.57' y='213.63' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='190.64' y='373.19' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='296.06' y='532.74' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='463.25' y='54.07' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='252.39' y='213.63' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='401.47' y='373.19' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='463.25' y='213.63' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='612.31' y='373.19' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='674.08' y='213.63' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='261.27' y='54.07' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='50.45' y='213.63' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='199.54' y='373.19' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='304.91' y='532.74' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='261.27' y='213.63' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='410.33' y='373.19' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='472.10' y='213.63' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='621.16' y='373.19' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='682.93' y='213.63' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='511.32' y='355.95' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>?</text>
+<text x='256.84' y='75.84' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_1</text>
+<text x='46.01' y='235.40' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_3</text>
+<text x='195.09' y='394.96' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_7</text>
+<text x='300.48' y='554.52' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='21.10px' lengthAdjust='spacingAndGlyphs'>1_10</text>
+<text x='467.67' y='75.84' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_2</text>
+<text x='256.84' y='235.40' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_5</text>
+<text x='405.90' y='394.96' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_8</text>
+<text x='467.67' y='235.40' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_6</text>
+<text x='616.73' y='394.96' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_9</text>
+<text x='678.51' y='235.40' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_4</text>
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='0.00' y='9.08' style='font-size: 13.20px; font-family: sans;' textLength='52.84px' lengthAdjust='spacingAndGlyphs'>Pedigree</text>
+<text x='2.74' y='9.08' style='font-size: 13.20px; font-family: sans;' textLength='52.84px' lengthAdjust='spacingAndGlyphs'>Pedigree</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot/ped-simple-affection-ggplot.svg
+++ b/tests/testthat/_snaps/plot/ped-simple-affection-ggplot.svg
@@ -19,67 +19,76 @@
 </defs>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 <rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
-<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: none;' />
-<line x1='270.43' y1='38.07' x2='452.22' y2='38.07' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='61.87' y1='188.19' x2='243.83' y2='188.19' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='209.27' y1='338.30' x2='391.14' y2='338.30' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='478.90' y1='188.19' x2='660.68' y2='188.19' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='209.27' y1='340.26' x2='391.14' y2='340.26' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='48.62' y1='178.28' x2='48.62' y2='148.56' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='674.02' y1='178.28' x2='674.02' y2='148.56' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='48.62' y1='148.56' x2='674.02' y2='148.56' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='361.32' y1='148.56' x2='361.32' y2='115.38' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='361.32' y1='115.38' x2='361.32' y2='71.25' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='361.32' y1='71.25' x2='361.32' y2='38.07' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='196.03' y1='328.40' x2='196.03' y2='298.67' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='196.03' y1='298.67' x2='196.03' y2='298.67' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='196.03' y1='298.67' x2='196.03' y2='265.50' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='196.03' y1='265.50' x2='152.86' y2='221.36' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='152.86' y1='221.36' x2='152.86' y2='188.19' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='404.48' y1='328.40' x2='508.71' y2='298.67' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='612.94' y1='328.40' x2='508.71' y2='298.67' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='508.71' y1='298.67' x2='508.71' y2='298.67' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='508.71' y1='298.67' x2='508.71' y2='265.50' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='508.71' y1='265.50' x2='569.79' y2='221.36' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='569.79' y1='221.36' x2='569.79' y2='188.19' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='300.24' y1='478.51' x2='300.24' y2='448.79' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='300.24' y1='448.79' x2='300.24' y2='448.79' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='300.24' y1='448.79' x2='300.24' y2='415.61' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='300.24' y1='415.61' x2='300.24' y2='371.48' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='300.24' y1='371.48' x2='300.24' y2='338.30' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<polygon points='243.84,28.16 243.84,47.98 270.34,47.98 270.34,28.16 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FF0000;' />
-<polygon points='35.38,178.28 35.38,198.10 61.87,198.10 61.87,178.28 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='209.28,338.30 209.17,339.57 208.85,340.82 208.31,342.02 207.57,343.17 206.65,344.23 205.55,345.20 204.29,346.05 202.90,346.78 201.39,347.36 199.80,347.80 198.15,348.08 196.46,348.21 194.76,348.17 193.08,347.96 191.46,347.60 189.90,347.09 188.45,346.43 187.12,345.64 185.94,344.73 184.93,343.71 184.10,342.60 183.46,341.43 183.03,340.20 182.81,338.94 182.81,337.67 183.03,336.41 183.46,335.18 184.10,334.01 184.93,332.90 185.94,331.88 187.12,330.97 188.45,330.18 189.90,329.52 191.46,329.01 193.08,328.64 194.76,328.44 196.46,328.40 198.15,328.52 199.80,328.81 201.39,329.24 202.90,329.83 204.29,330.56 205.55,331.41 206.65,332.38 207.57,333.44 208.31,334.59 208.85,335.79 209.17,337.04 209.28,338.30 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='313.49,488.42 313.38,489.69 313.06,490.93 312.52,492.14 311.79,493.28 310.86,494.35 309.76,495.31 308.50,496.17 307.11,496.89 305.61,497.48 304.01,497.92 302.36,498.20 300.67,498.32 298.97,498.28 297.30,498.08 295.67,497.72 294.12,497.20 292.66,496.55 291.34,495.75 290.16,494.84 289.14,493.83 288.31,492.72 287.67,491.54 287.24,490.31 287.02,489.06 287.02,487.79 287.24,486.53 287.67,485.30 288.31,484.12 289.14,483.02 290.16,482.00 291.34,481.09 292.66,480.29 294.12,479.64 295.67,479.12 297.30,478.76 298.97,478.56 300.67,478.52 302.36,478.64 304.01,478.92 305.61,479.36 307.11,479.95 308.50,480.67 309.76,481.53 310.86,482.49 311.79,483.56 312.52,484.70 313.06,485.91 313.38,487.15 313.49,488.42 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='478.81,38.07 478.70,39.34 478.37,40.58 477.84,41.79 477.10,42.93 476.18,44.00 475.07,44.96 473.82,45.82 472.43,46.54 470.92,47.13 469.33,47.57 467.67,47.85 465.98,47.97 464.29,47.93 462.61,47.73 460.98,47.37 459.43,46.86 457.98,46.20 456.65,45.41 455.47,44.49 454.46,43.48 453.62,42.37 452.98,41.19 452.55,39.96 452.34,38.71 452.34,37.44 452.55,36.18 452.98,34.95 453.62,33.77 454.46,32.67 455.47,31.65 456.65,30.74 457.98,29.95 459.43,29.29 460.98,28.77 462.61,28.41 464.29,28.21 465.98,28.17 467.67,28.29 469.33,28.57 470.92,29.01 472.43,29.60 473.82,30.32 475.07,31.18 476.18,32.15 477.10,33.21 477.84,34.35 478.37,35.56 478.70,36.80 478.81,38.07 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='270.34,188.19 270.23,189.45 269.91,190.70 269.37,191.91 268.63,193.05 267.71,194.11 266.61,195.08 265.35,195.93 263.96,196.66 262.45,197.25 260.86,197.69 259.21,197.97 257.52,198.09 255.82,198.05 254.14,197.85 252.52,197.49 250.96,196.97 249.51,196.31 248.18,195.52 247.00,194.61 245.99,193.59 245.16,192.49 244.52,191.31 244.09,190.08 243.87,188.82 243.87,187.55 244.09,186.29 244.52,185.07 245.16,183.89 245.99,182.78 247.00,181.77 248.18,180.85 249.51,180.06 250.96,179.40 252.52,178.89 254.14,178.53 255.82,178.33 257.52,178.28 259.21,178.41 260.86,178.69 262.45,179.13 263.96,179.72 265.35,180.44 266.61,181.29 267.71,182.26 268.63,183.33 269.37,184.47 269.91,185.67 270.23,186.92 270.34,188.19 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FF0000;' />
-<polygon points='391.23,328.40 391.23,348.21 417.73,348.21 417.73,328.40 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FF0000;' />
-<polygon points='452.31,178.28 452.31,198.10 478.81,198.10 478.81,178.28 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='599.70,328.40 599.70,348.21 626.19,348.21 626.19,328.40 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
-<polygon points='687.27,188.19 687.16,189.45 686.84,190.70 686.30,191.91 685.57,193.05 684.64,194.11 683.54,195.08 682.28,195.93 680.89,196.66 679.39,197.25 677.79,197.69 676.14,197.97 674.45,198.09 672.75,198.05 671.08,197.85 669.45,197.49 667.90,196.97 666.45,196.31 665.12,195.52 663.94,194.61 662.92,193.59 662.09,192.49 661.45,191.31 661.02,190.08 660.80,188.82 660.80,187.55 661.02,186.29 661.45,185.07 662.09,183.89 662.92,182.78 663.94,181.77 665.12,180.85 666.45,180.06 667.90,179.40 669.45,178.89 671.08,178.53 672.75,178.33 674.45,178.28 676.14,178.41 677.79,178.69 679.39,179.13 680.89,179.72 682.28,180.44 683.54,181.29 684.64,182.26 685.57,183.33 686.30,184.47 686.84,185.67 687.16,186.92 687.27,188.19 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FF0000;' />
-<line x1='241.19' y1='49.93' x2='272.93' y2='26.18' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='32.73' y1='200.05' x2='64.52' y2='176.33' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='449.71' y1='49.93' x2='481.40' y2='26.18' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<line x1='241.19' y1='200.05' x2='272.93' y2='176.33' style='stroke-width: 2.13; stroke-linecap: butt;' />
-<text x='257.09' y='67.91' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_1</text>
-<text x='48.62' y='218.02' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_3</text>
-<text x='196.03' y='368.14' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_7</text>
-<text x='300.24' y='518.25' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='21.10px' lengthAdjust='spacingAndGlyphs'>1_10</text>
-<text x='465.56' y='67.91' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_2</text>
-<text x='257.09' y='218.02' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_5</text>
-<text x='404.48' y='368.14' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_8</text>
-<text x='465.56' y='218.02' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_6</text>
-<text x='612.94' y='368.14' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_9</text>
-<text x='674.02' y='218.02' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_4</text>
-<text x='257.09' y='102.73' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='48.62' y='252.85' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='196.03' y='402.97' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='300.24' y='553.08' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='257.09' y='252.85' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='404.48' y='402.97' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='465.56' y='252.85' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
-<text x='612.94' y='402.97' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='674.02' y='252.85' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
-<text x='508.71' y='316.80' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>?</text>
+</g>
+<defs>
+  <clipPath id='cpMi43NHw3MjAuMDB8MC4wMHw1NzMuMjY='>
+    <rect x='2.74' y='0.00' width='717.26' height='573.26' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMi43NHw3MjAuMDB8MC4wMHw1NzMuMjY=)'>
+<rect x='2.74' y='0.00' width='717.26' height='573.26' style='stroke-width: 1.07; stroke: none;' />
+<line x1='272.14' y1='37.89' x2='453.24' y2='37.89' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='64.38' y1='187.29' x2='245.64' y2='187.29' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='211.21' y1='336.69' x2='392.39' y2='336.69' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='479.82' y1='187.29' x2='660.91' y2='187.29' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='211.21' y1='338.64' x2='392.39' y2='338.64' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='51.18' y1='177.43' x2='51.18' y2='147.85' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='674.20' y1='177.43' x2='674.20' y2='147.85' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='51.18' y1='147.85' x2='674.20' y2='147.85' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='362.69' y1='147.85' x2='362.69' y2='114.83' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='362.69' y1='114.83' x2='362.69' y2='70.91' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='362.69' y1='70.91' x2='362.69' y2='37.89' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='198.03' y1='326.83' x2='198.03' y2='297.25' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='198.03' y1='297.25' x2='198.03' y2='297.25' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='198.03' y1='297.25' x2='198.03' y2='264.23' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='198.03' y1='264.23' x2='155.02' y2='220.31' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='155.02' y1='220.31' x2='155.02' y2='187.29' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='405.68' y1='326.83' x2='509.51' y2='297.25' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='613.35' y1='326.83' x2='509.51' y2='297.25' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='509.51' y1='297.25' x2='509.51' y2='297.25' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='509.51' y1='297.25' x2='509.51' y2='264.23' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='509.51' y1='264.23' x2='570.36' y2='220.31' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='570.36' y1='220.31' x2='570.36' y2='187.29' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='301.84' y1='476.24' x2='301.84' y2='446.66' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='301.84' y1='446.66' x2='301.84' y2='446.66' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='301.84' y1='446.66' x2='301.84' y2='413.64' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='301.84' y1='413.64' x2='301.84' y2='369.71' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='301.84' y1='369.71' x2='301.84' y2='336.69' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<polygon points='245.66,28.03 245.66,47.75 272.05,47.75 272.05,28.03 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FF0000;' />
+<polygon points='37.98,177.43 37.98,197.15 64.38,197.15 64.38,177.43 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='211.22,336.69 211.11,337.96 210.79,339.20 210.26,340.40 209.52,341.53 208.60,342.59 207.51,343.55 206.25,344.40 204.87,345.13 203.37,345.71 201.78,346.15 200.13,346.43 198.45,346.55 196.76,346.51 195.09,346.31 193.47,345.95 191.92,345.44 190.47,344.78 189.15,343.99 187.98,343.09 186.96,342.07 186.13,340.97 185.50,339.80 185.07,338.58 184.85,337.33 184.85,336.06 185.07,334.81 185.50,333.59 186.13,332.42 186.96,331.32 187.98,330.30 189.15,329.40 190.47,328.61 191.92,327.95 193.47,327.44 195.09,327.08 196.76,326.88 198.45,326.84 200.13,326.96 201.78,327.24 203.37,327.68 204.87,328.26 206.25,328.99 207.51,329.84 208.60,330.80 209.52,331.86 210.26,332.99 210.79,334.19 211.11,335.43 211.22,336.69 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='315.04,486.10 314.93,487.36 314.61,488.60 314.07,489.80 313.34,490.94 312.42,492.00 311.32,492.96 310.07,493.81 308.68,494.53 307.18,495.11 305.60,495.55 303.95,495.83 302.26,495.95 300.57,495.91 298.90,495.71 297.28,495.35 295.74,494.84 294.29,494.18 292.97,493.40 291.79,492.49 290.78,491.48 289.95,490.38 289.32,489.20 288.89,487.98 288.67,486.73 288.67,485.47 288.89,484.21 289.32,482.99 289.95,481.82 290.78,480.72 291.79,479.71 292.97,478.80 294.29,478.01 295.74,477.36 297.28,476.84 298.90,476.48 300.57,476.28 302.26,476.24 303.95,476.36 305.60,476.64 307.18,477.08 308.68,477.67 310.07,478.39 311.32,479.24 312.42,480.20 313.34,481.26 314.07,482.40 314.61,483.60 314.93,484.84 315.04,486.10 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='479.72,37.89 479.62,39.15 479.29,40.39 478.76,41.59 478.03,42.73 477.10,43.79 476.01,44.75 474.75,45.60 473.37,46.32 471.87,46.91 470.28,47.34 468.63,47.62 466.95,47.75 465.26,47.70 463.59,47.50 461.97,47.14 460.42,46.63 458.98,45.98 457.65,45.19 456.48,44.28 455.47,43.27 454.64,42.17 454.00,41.00 453.57,39.77 453.36,38.52 453.36,37.26 453.57,36.01 454.00,34.78 454.64,33.61 455.47,32.51 456.48,31.50 457.65,30.59 458.98,29.80 460.42,29.15 461.97,28.64 463.59,28.28 465.26,28.07 466.95,28.03 468.63,28.16 470.28,28.44 471.87,28.87 473.37,29.46 474.75,30.18 476.01,31.03 477.10,31.99 478.03,33.05 478.76,34.19 479.29,35.39 479.62,36.63 479.72,37.89 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='272.05,187.29 271.94,188.55 271.62,189.79 271.09,190.99 270.35,192.13 269.43,193.19 268.33,194.15 267.08,195.00 265.69,195.72 264.20,196.31 262.61,196.75 260.96,197.03 259.28,197.15 257.59,197.11 255.92,196.91 254.29,196.55 252.75,196.03 251.30,195.38 249.98,194.59 248.80,193.68 247.79,192.67 246.96,191.57 246.33,190.40 245.90,189.18 245.68,187.92 245.68,186.66 245.90,185.41 246.33,184.19 246.96,183.01 247.79,181.91 248.80,180.90 249.98,179.99 251.30,179.21 252.75,178.55 254.29,178.04 255.92,177.68 257.59,177.48 259.28,177.44 260.96,177.56 262.61,177.84 264.20,178.28 265.69,178.86 267.08,179.58 268.33,180.43 269.43,181.39 270.35,182.45 271.09,183.59 271.62,184.79 271.94,186.03 272.05,187.29 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FF0000;' />
+<polygon points='392.48,326.83 392.48,346.56 418.88,346.56 418.88,326.83 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FF0000;' />
+<polygon points='453.33,177.43 453.33,197.15 479.72,197.15 479.72,177.43 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='600.15,326.83 600.15,346.56 626.55,346.56 626.55,326.83 ' style='stroke-width: 2.13; stroke: #00FF00; stroke-linecap: butt; fill: #FFFFFF;' />
+<polygon points='687.40,187.29 687.29,188.55 686.97,189.79 686.43,190.99 685.70,192.13 684.78,193.19 683.68,194.15 682.43,195.00 681.04,195.72 679.54,196.31 677.95,196.75 676.31,197.03 674.62,197.15 672.93,197.11 671.26,196.91 669.64,196.55 668.10,196.03 666.65,195.38 665.33,194.59 664.15,193.68 663.14,192.67 662.31,191.57 661.67,190.40 661.25,189.18 661.03,187.92 661.03,186.66 661.25,185.41 661.67,184.19 662.31,183.01 663.14,181.91 664.15,180.90 665.33,179.99 666.65,179.21 668.10,178.55 669.64,178.04 671.26,177.68 672.93,177.48 674.62,177.44 676.31,177.56 677.95,177.84 679.54,178.28 681.04,178.86 682.43,179.58 683.68,180.43 684.78,181.39 685.70,182.45 686.43,183.59 686.97,184.79 687.29,186.03 687.40,187.29 ' style='stroke-width: 2.13; stroke-linecap: butt; fill: #FF0000;' />
+<line x1='243.01' y1='49.69' x2='274.64' y2='26.06' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='35.34' y1='199.10' x2='67.02' y2='175.49' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='450.74' y1='49.69' x2='482.31' y2='26.06' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<line x1='243.01' y1='199.10' x2='274.64' y2='175.49' style='stroke-width: 2.13; stroke-linecap: butt;' />
+<text x='258.85' y='70.86' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_1</text>
+<text x='51.18' y='220.26' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_3</text>
+<text x='198.03' y='369.67' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_7</text>
+<text x='301.84' y='519.07' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='21.10px' lengthAdjust='spacingAndGlyphs'>1_10</text>
+<text x='466.53' y='70.86' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_2</text>
+<text x='258.85' y='220.26' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_5</text>
+<text x='405.68' y='369.67' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_8</text>
+<text x='466.53' y='220.26' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_6</text>
+<text x='613.35' y='369.67' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_9</text>
+<text x='674.20' y='220.26' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='15.83px' lengthAdjust='spacingAndGlyphs'>1_4</text>
+<text x='258.85' y='105.52' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='51.18' y='254.93' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='198.03' y='404.33' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='301.84' y='553.73' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='258.85' y='254.93' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='405.68' y='404.33' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='466.53' y='254.93' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='613.35' y='404.33' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='674.20' y='254.93' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='509.51' y='315.31' text-anchor='middle' style='font-size: 9.48px; font-family: sans;' textLength='5.28px' lengthAdjust='spacingAndGlyphs'>?</text>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 </svg>

--- a/tests/testthat/_snaps/plot_fct.md
+++ b/tests/testthat/_snaps/plot_fct.md
@@ -529,269 +529,269 @@
       260   <NA>    NA      NA   NA        <NA>
       261   <NA>    NA      NA   NA        <NA>
       262   <NA>    NA      NA   NA        <NA>
-                                                          tips adjx adjy    lty lwd
-      1   <span style='font-size:14px'><b>1_135</b></span><br>   NA   NA   <NA> 1.0
-      2   <span style='font-size:14px'><b>1_101</b></span><br>   NA   NA   <NA> 1.0
-      3   <span style='font-size:14px'><b>1_109</b></span><br>   NA   NA   <NA> 1.0
-      4   <span style='font-size:14px'><b>1_121</b></span><br>   NA   NA   <NA> 1.0
-      5   <span style='font-size:14px'><b>1_136</b></span><br>   NA   NA   <NA> 1.0
-      6   <span style='font-size:14px'><b>1_102</b></span><br>   NA   NA   <NA> 1.0
-      7   <span style='font-size:14px'><b>1_110</b></span><br>   NA   NA   <NA> 1.0
-      8   <span style='font-size:14px'><b>1_122</b></span><br>   NA   NA   <NA> 1.0
-      9   <span style='font-size:14px'><b>1_103</b></span><br>   NA   NA   <NA> 1.0
-      10  <span style='font-size:14px'><b>1_111</b></span><br>   NA   NA   <NA> 1.0
-      11  <span style='font-size:14px'><b>1_123</b></span><br>   NA   NA   <NA> 1.0
-      12  <span style='font-size:14px'><b>1_104</b></span><br>   NA   NA   <NA> 1.0
-      13  <span style='font-size:14px'><b>1_112</b></span><br>   NA   NA   <NA> 1.0
-      14  <span style='font-size:14px'><b>1_124</b></span><br>   NA   NA   <NA> 1.0
-      15  <span style='font-size:14px'><b>1_137</b></span><br>   NA   NA   <NA> 1.0
-      16  <span style='font-size:14px'><b>1_114</b></span><br>   NA   NA   <NA> 1.0
-      17  <span style='font-size:14px'><b>1_127</b></span><br>   NA   NA   <NA> 1.0
-      18  <span style='font-size:14px'><b>1_138</b></span><br>   NA   NA   <NA> 1.0
-      19  <span style='font-size:14px'><b>1_139</b></span><br>   NA   NA   <NA> 1.0
-      20  <span style='font-size:14px'><b>1_128</b></span><br>   NA   NA   <NA> 1.0
-      21  <span style='font-size:14px'><b>1_105</b></span><br>   NA   NA   <NA> 1.0
-      22  <span style='font-size:14px'><b>1_140</b></span><br>   NA   NA   <NA> 1.0
-      23  <span style='font-size:14px'><b>1_125</b></span><br>   NA   NA   <NA> 1.0
-      24  <span style='font-size:14px'><b>1_106</b></span><br>   NA   NA   <NA> 1.0
-      25  <span style='font-size:14px'><b>1_141</b></span><br>   NA   NA   <NA> 1.0
-      26  <span style='font-size:14px'><b>1_126</b></span><br>   NA   NA   <NA> 1.0
-      27  <span style='font-size:14px'><b>1_107</b></span><br>   NA   NA   <NA> 1.0
-      28  <span style='font-size:14px'><b>1_114</b></span><br>   NA   NA   <NA> 1.0
-      29  <span style='font-size:14px'><b>1_129</b></span><br>   NA   NA   <NA> 1.0
-      30  <span style='font-size:14px'><b>1_108</b></span><br>   NA   NA   <NA> 1.0
-      31  <span style='font-size:14px'><b>1_115</b></span><br>   NA   NA   <NA> 1.0
-      32  <span style='font-size:14px'><b>1_130</b></span><br>   NA   NA   <NA> 1.0
-      33  <span style='font-size:14px'><b>1_112</b></span><br>   NA   NA   <NA> 1.0
-      34  <span style='font-size:14px'><b>1_131</b></span><br>   NA   NA   <NA> 1.0
-      35  <span style='font-size:14px'><b>1_118</b></span><br>   NA   NA   <NA> 1.0
-      36  <span style='font-size:14px'><b>1_132</b></span><br>   NA   NA   <NA> 1.0
-      37  <span style='font-size:14px'><b>1_117</b></span><br>   NA   NA   <NA> 1.0
-      38  <span style='font-size:14px'><b>1_133</b></span><br>   NA   NA   <NA> 1.0
-      39  <span style='font-size:14px'><b>1_116</b></span><br>   NA   NA   <NA> 1.0
-      40  <span style='font-size:14px'><b>1_134</b></span><br>   NA   NA   <NA> 1.0
-      41  <span style='font-size:14px'><b>1_119</b></span><br>   NA   NA   <NA> 1.0
-      42  <span style='font-size:14px'><b>1_120</b></span><br>   NA   NA   <NA> 1.0
-      43  <span style='font-size:14px'><b>1_135</b></span><br>  0.5  0.5   <NA>  NA
-      44  <span style='font-size:14px'><b>1_101</b></span><br>  0.5  0.5   <NA>  NA
-      45  <span style='font-size:14px'><b>1_109</b></span><br>  0.5  0.5   <NA>  NA
-      46  <span style='font-size:14px'><b>1_121</b></span><br>  0.5  0.5   <NA>  NA
-      47  <span style='font-size:14px'><b>1_136</b></span><br>  0.5  0.5   <NA>  NA
-      48  <span style='font-size:14px'><b>1_102</b></span><br>  0.5  0.5   <NA>  NA
-      49  <span style='font-size:14px'><b>1_110</b></span><br>  0.5  0.5   <NA>  NA
-      50  <span style='font-size:14px'><b>1_122</b></span><br>  0.5  0.5   <NA>  NA
-      51  <span style='font-size:14px'><b>1_103</b></span><br>  0.5  0.5   <NA>  NA
-      52  <span style='font-size:14px'><b>1_111</b></span><br>  0.5  0.5   <NA>  NA
-      53  <span style='font-size:14px'><b>1_123</b></span><br>  0.5  0.5   <NA>  NA
-      54  <span style='font-size:14px'><b>1_104</b></span><br>  0.5  0.5   <NA>  NA
-      55  <span style='font-size:14px'><b>1_112</b></span><br>  0.5  0.5   <NA>  NA
-      56  <span style='font-size:14px'><b>1_124</b></span><br>  0.5  0.5   <NA>  NA
-      57  <span style='font-size:14px'><b>1_137</b></span><br>  0.5  0.5   <NA>  NA
-      58  <span style='font-size:14px'><b>1_114</b></span><br>  0.5  0.5   <NA>  NA
-      59  <span style='font-size:14px'><b>1_127</b></span><br>  0.5  0.5   <NA>  NA
-      60  <span style='font-size:14px'><b>1_138</b></span><br>  0.5  0.5   <NA>  NA
-      61  <span style='font-size:14px'><b>1_139</b></span><br>  0.5  0.5   <NA>  NA
-      62  <span style='font-size:14px'><b>1_128</b></span><br>  0.5  0.5   <NA>  NA
-      63  <span style='font-size:14px'><b>1_105</b></span><br>  0.5  0.5   <NA>  NA
-      64  <span style='font-size:14px'><b>1_140</b></span><br>  0.5  0.5   <NA>  NA
-      65  <span style='font-size:14px'><b>1_125</b></span><br>  0.5  0.5   <NA>  NA
-      66  <span style='font-size:14px'><b>1_106</b></span><br>  0.5  0.5   <NA>  NA
-      67  <span style='font-size:14px'><b>1_141</b></span><br>  0.5  0.5   <NA>  NA
-      68  <span style='font-size:14px'><b>1_126</b></span><br>  0.5  0.5   <NA>  NA
-      69  <span style='font-size:14px'><b>1_107</b></span><br>  0.5  0.5   <NA>  NA
-      70  <span style='font-size:14px'><b>1_114</b></span><br>  0.5  0.5   <NA>  NA
-      71  <span style='font-size:14px'><b>1_129</b></span><br>  0.5  0.5   <NA>  NA
-      72  <span style='font-size:14px'><b>1_108</b></span><br>  0.5  0.5   <NA>  NA
-      73  <span style='font-size:14px'><b>1_115</b></span><br>  0.5  0.5   <NA>  NA
-      74  <span style='font-size:14px'><b>1_130</b></span><br>  0.5  0.5   <NA>  NA
-      75  <span style='font-size:14px'><b>1_112</b></span><br>  0.5  0.5   <NA>  NA
-      76  <span style='font-size:14px'><b>1_131</b></span><br>  0.5  0.5   <NA>  NA
-      77  <span style='font-size:14px'><b>1_118</b></span><br>  0.5  0.5   <NA>  NA
-      78  <span style='font-size:14px'><b>1_132</b></span><br>  0.5  0.5   <NA>  NA
-      79  <span style='font-size:14px'><b>1_117</b></span><br>  0.5  0.5   <NA>  NA
-      80  <span style='font-size:14px'><b>1_133</b></span><br>  0.5  0.5   <NA>  NA
-      81  <span style='font-size:14px'><b>1_116</b></span><br>  0.5  0.5   <NA>  NA
-      82  <span style='font-size:14px'><b>1_134</b></span><br>  0.5  0.5   <NA>  NA
-      83  <span style='font-size:14px'><b>1_119</b></span><br>  0.5  0.5   <NA>  NA
-      84  <span style='font-size:14px'><b>1_120</b></span><br>  0.5  0.5   <NA>  NA
-      85                                                  <NA>   NA   NA  solid 1.0
-      86                                                  <NA>   NA   NA  solid 1.0
-      87                                                  <NA>   NA   NA  solid 1.0
-      88                                                  <NA>   NA   NA  solid 1.0
-      89                                                  <NA>   NA   NA  solid 1.0
-      90                                                  <NA>   NA   NA  solid 1.0
-      91                                                  <NA>   NA   NA  solid 1.0
-      92                                                  <NA>  0.5  1.0   <NA>  NA
-      93                                                  <NA>   NA   NA  solid 1.0
-      94                                                  <NA>   NA   NA  solid 1.0
-      95                                                  <NA>   NA   NA  solid 1.0
-      96                                                  <NA>   NA   NA  solid 1.0
-      97                                                  <NA>  0.5  0.5   <NA>  NA
-      98                                                  <NA>  0.5  0.5   <NA>  NA
-      99                                                  <NA>  0.5  0.5   <NA>  NA
-      100                                                 <NA>   NA   NA  solid 1.0
-      101                                                 <NA>   NA   NA  solid 1.0
-      102                                                 <NA>   NA   NA  solid 1.0
-      103                                                 <NA>   NA   NA  solid 1.0
-      104                                                 <NA>   NA   NA  solid 1.0
-      105                                                 <NA>  0.5  0.5   <NA>  NA
-      106                                                 <NA>  0.5  0.5   <NA>  NA
-      107                                                 <NA>  0.5  0.5   <NA>  NA
-      108                                                 <NA>   NA   NA   <NA>  NA
-      109                                                 <NA>   NA   NA   <NA>  NA
-      110                                                 <NA>   NA   NA  solid 2.5
-      111                                                 <NA>   NA   NA  solid 2.5
-      112                                                 <NA>   NA   NA  solid 1.0
-      113                                                 <NA>   NA   NA  solid 1.0
-      114                                                 <NA>   NA   NA  solid 1.0
-      115                                                 <NA>   NA   NA  solid 1.0
-      116                                                 <NA>   NA   NA  solid 1.0
-      117                                                 <NA>   NA   NA  solid 1.0
-      118                                                 <NA>   NA   NA  solid 1.0
-      119                                                 <NA>   NA   NA  solid 1.0
-      120                                                 <NA>   NA   NA  solid 1.0
-      121                                                 <NA>   NA   NA  solid 1.0
-      122                                                 <NA>   NA   NA  solid 1.0
-      123                                                 <NA>   NA   NA  solid 1.0
-      124 <span style='font-size:14px'><b>1_135</b></span><br>  0.5  1.0   <NA>  NA
-      125 <span style='font-size:14px'><b>1_101</b></span><br>  0.5  1.0   <NA>  NA
-      126 <span style='font-size:14px'><b>1_109</b></span><br>  0.5  1.0   <NA>  NA
-      127 <span style='font-size:14px'><b>1_121</b></span><br>  0.5  1.0   <NA>  NA
-      128 <span style='font-size:14px'><b>1_136</b></span><br>  0.5  1.0   <NA>  NA
-      129 <span style='font-size:14px'><b>1_102</b></span><br>  0.5  1.0   <NA>  NA
-      130 <span style='font-size:14px'><b>1_110</b></span><br>  0.5  1.0   <NA>  NA
-      131 <span style='font-size:14px'><b>1_122</b></span><br>  0.5  1.0   <NA>  NA
-      132 <span style='font-size:14px'><b>1_103</b></span><br>  0.5  1.0   <NA>  NA
-      133 <span style='font-size:14px'><b>1_111</b></span><br>  0.5  1.0   <NA>  NA
-      134 <span style='font-size:14px'><b>1_123</b></span><br>  0.5  1.0   <NA>  NA
-      135 <span style='font-size:14px'><b>1_104</b></span><br>  0.5  1.0   <NA>  NA
-      136 <span style='font-size:14px'><b>1_112</b></span><br>  0.5  1.0   <NA>  NA
-      137 <span style='font-size:14px'><b>1_124</b></span><br>  0.5  1.0   <NA>  NA
-      138 <span style='font-size:14px'><b>1_137</b></span><br>  0.5  1.0   <NA>  NA
-      139 <span style='font-size:14px'><b>1_114</b></span><br>  0.5  1.0   <NA>  NA
-      140 <span style='font-size:14px'><b>1_127</b></span><br>  0.5  1.0   <NA>  NA
-      141 <span style='font-size:14px'><b>1_138</b></span><br>  0.5  1.0   <NA>  NA
-      142 <span style='font-size:14px'><b>1_139</b></span><br>  0.5  1.0   <NA>  NA
-      143 <span style='font-size:14px'><b>1_128</b></span><br>  0.5  1.0   <NA>  NA
-      144 <span style='font-size:14px'><b>1_105</b></span><br>  0.5  1.0   <NA>  NA
-      145 <span style='font-size:14px'><b>1_140</b></span><br>  0.5  1.0   <NA>  NA
-      146 <span style='font-size:14px'><b>1_125</b></span><br>  0.5  1.0   <NA>  NA
-      147 <span style='font-size:14px'><b>1_106</b></span><br>  0.5  1.0   <NA>  NA
-      148 <span style='font-size:14px'><b>1_141</b></span><br>  0.5  1.0   <NA>  NA
-      149 <span style='font-size:14px'><b>1_126</b></span><br>  0.5  1.0   <NA>  NA
-      150 <span style='font-size:14px'><b>1_107</b></span><br>  0.5  1.0   <NA>  NA
-      151 <span style='font-size:14px'><b>1_114</b></span><br>  0.5  1.0   <NA>  NA
-      152 <span style='font-size:14px'><b>1_129</b></span><br>  0.5  1.0   <NA>  NA
-      153 <span style='font-size:14px'><b>1_108</b></span><br>  0.5  1.0   <NA>  NA
-      154 <span style='font-size:14px'><b>1_115</b></span><br>  0.5  1.0   <NA>  NA
-      155 <span style='font-size:14px'><b>1_130</b></span><br>  0.5  1.0   <NA>  NA
-      156 <span style='font-size:14px'><b>1_112</b></span><br>  0.5  1.0   <NA>  NA
-      157 <span style='font-size:14px'><b>1_131</b></span><br>  0.5  1.0   <NA>  NA
-      158 <span style='font-size:14px'><b>1_118</b></span><br>  0.5  1.0   <NA>  NA
-      159 <span style='font-size:14px'><b>1_132</b></span><br>  0.5  1.0   <NA>  NA
-      160 <span style='font-size:14px'><b>1_117</b></span><br>  0.5  1.0   <NA>  NA
-      161 <span style='font-size:14px'><b>1_133</b></span><br>  0.5  1.0   <NA>  NA
-      162 <span style='font-size:14px'><b>1_116</b></span><br>  0.5  1.0   <NA>  NA
-      163 <span style='font-size:14px'><b>1_134</b></span><br>  0.5  1.0   <NA>  NA
-      164 <span style='font-size:14px'><b>1_119</b></span><br>  0.5  1.0   <NA>  NA
-      165 <span style='font-size:14px'><b>1_120</b></span><br>  0.5  1.0   <NA>  NA
-      166 <span style='font-size:14px'><b>1_135</b></span><br>  0.5  1.0   <NA>  NA
-      167 <span style='font-size:14px'><b>1_101</b></span><br>  0.5  1.0   <NA>  NA
-      168 <span style='font-size:14px'><b>1_136</b></span><br>  0.5  1.0   <NA>  NA
-      169 <span style='font-size:14px'><b>1_102</b></span><br>  0.5  1.0   <NA>  NA
-      170 <span style='font-size:14px'><b>1_103</b></span><br>  0.5  1.0   <NA>  NA
-      171 <span style='font-size:14px'><b>1_112</b></span><br>  0.5  1.0   <NA>  NA
-      172 <span style='font-size:14px'><b>1_124</b></span><br>  0.5  1.0   <NA>  NA
-      173 <span style='font-size:14px'><b>1_114</b></span><br>  0.5  1.0   <NA>  NA
-      174 <span style='font-size:14px'><b>1_114</b></span><br>  0.5  1.0   <NA>  NA
-      175 <span style='font-size:14px'><b>1_112</b></span><br>  0.5  1.0   <NA>  NA
-      176 <span style='font-size:14px'><b>1_134</b></span><br>  0.5  1.0   <NA>  NA
-      177                                                 <NA>   NA   NA  solid 1.0
-      178                                                 <NA>   NA   NA  solid 1.0
-      179                                                 <NA>   NA   NA  solid 1.0
-      180                                                 <NA>   NA   NA  solid 1.0
-      181                                                 <NA>   NA   NA  solid 1.0
-      182                                                 <NA>   NA   NA  solid 1.0
-      183                                                 <NA>   NA   NA  solid 1.0
-      184                                                 <NA>   NA   NA  solid 1.0
-      185                                                 <NA>   NA   NA  solid 1.0
-      186                                                 <NA>   NA   NA  solid 1.0
-      187                                                 <NA>   NA   NA  solid 1.0
-      188                                                 <NA>   NA   NA  solid 1.0
-      189                                                 <NA>   NA   NA  solid 1.0
-      190                                                 <NA>   NA   NA  solid 1.0
-      191                                                 <NA>   NA   NA  solid 1.0
-      192                                                 <NA>   NA   NA  solid 1.0
-      193                                                 <NA>   NA   NA  solid 1.0
-      194                                                 <NA>   NA   NA  solid 1.0
-      195                                                 <NA>   NA   NA  solid 1.0
-      196                                                 <NA>   NA   NA  solid 1.0
-      197                                                 <NA>   NA   NA  solid 1.0
-      198                                                 <NA>   NA   NA  solid 1.0
-      199                                                 <NA>   NA   NA  solid 1.0
-      200                                                 <NA>   NA   NA  solid 1.0
-      201                                                 <NA>   NA   NA  solid 1.0
-      202                                                 <NA>   NA   NA  solid 1.0
-      203                                                 <NA>   NA   NA  solid 1.0
-      204                                                 <NA>   NA   NA  solid 1.0
-      205                                                 <NA>   NA   NA  solid 1.0
-      206                                                 <NA>   NA   NA  solid 1.0
-      207                                                 <NA>   NA   NA  solid 1.0
-      208                                                 <NA>   NA   NA  solid 1.0
-      209                                                 <NA>   NA   NA  solid 1.0
-      210                                                 <NA>   NA   NA  solid 1.0
-      211                                                 <NA>   NA   NA  solid 1.0
-      212                                                 <NA>   NA   NA  solid 1.0
-      213                                                 <NA>   NA   NA  solid 1.0
-      214                                                 <NA>   NA   NA  solid 1.0
-      215                                                 <NA>   NA   NA  solid 1.0
-      216                                                 <NA>   NA   NA  solid 1.0
-      217                                                 <NA>   NA   NA  solid 1.0
-      218                                                 <NA>   NA   NA  solid 1.0
-      219                                                 <NA>   NA   NA  solid 1.0
-      220                                                 <NA>   NA   NA  solid 1.0
-      221                                                 <NA>   NA   NA  solid 1.0
-      222                                                 <NA>   NA   NA  solid 1.0
-      223                                                 <NA>   NA   NA  solid 1.0
-      224                                                 <NA>   NA   NA  solid 1.0
-      225                                                 <NA>   NA   NA  solid 1.0
-      226                                                 <NA>   NA   NA  solid 1.0
-      227                                                 <NA>   NA   NA  solid 1.0
-      228                                                 <NA>   NA   NA  solid 1.0
-      229                                                 <NA>   NA   NA  solid 1.0
-      230                                                 <NA>   NA   NA  solid 1.0
-      231                                                 <NA>   NA   NA  solid 1.0
-      232                                                 <NA>   NA   NA  solid 1.0
-      233                                                 <NA>   NA   NA  solid 1.0
-      234                                                 <NA>   NA   NA  solid 1.0
-      235                                                 <NA>   NA   NA  solid 1.0
-      236                                                 <NA>   NA   NA  solid 1.0
-      237                                                 <NA>   NA   NA  solid 1.0
-      238                                                 <NA>   NA   NA  solid 1.0
-      239                                                 <NA>   NA   NA  solid 1.0
-      240                                                 <NA>   NA   NA  solid 1.0
-      241                                                 <NA>   NA   NA  solid 1.0
-      242                                                 <NA>   NA   NA  solid 1.0
-      243                                                 <NA>   NA   NA  solid 1.0
-      244                                                 <NA>   NA   NA  solid 1.0
-      245                                                 <NA>   NA   NA  solid 1.0
-      246                                                 <NA>   NA   NA  solid 1.0
-      247                                                 <NA>   NA   NA  solid 1.0
-      248                                                 <NA>   NA   NA  solid 1.0
-      249                                                 <NA>   NA   NA  solid 1.0
-      250                                                 <NA>   NA   NA  solid 1.0
-      251                                                 <NA>   NA   NA  solid 1.0
-      252                                                 <NA>   NA   NA  solid 1.0
-      253                                                 <NA>   NA   NA  solid 1.0
-      254                                                 <NA>   NA   NA  solid 1.0
-      255                                                 <NA>   NA   NA  solid 1.0
-      256                                                 <NA>   NA   NA  solid 1.0
-      257                                                 <NA>   NA   NA  solid 1.0
-      258                                                 <NA>   NA   NA  solid 1.0
-      259                                                 <NA>   NA   NA  solid 1.0
-      260                                                 <NA>   NA   NA  solid 1.0
-      261                                                 <NA>   NA   NA dashed 1.0
-      262                                                 <NA>   NA   NA dashed 1.0
+                                                          tips lwd adjx adjy    lty
+      1   <span style='font-size:14px'><b>1_135</b></span><br> 1.0   NA   NA   <NA>
+      2   <span style='font-size:14px'><b>1_101</b></span><br> 1.0   NA   NA   <NA>
+      3   <span style='font-size:14px'><b>1_109</b></span><br> 1.0   NA   NA   <NA>
+      4   <span style='font-size:14px'><b>1_121</b></span><br> 1.0   NA   NA   <NA>
+      5   <span style='font-size:14px'><b>1_136</b></span><br> 1.0   NA   NA   <NA>
+      6   <span style='font-size:14px'><b>1_102</b></span><br> 1.0   NA   NA   <NA>
+      7   <span style='font-size:14px'><b>1_110</b></span><br> 1.0   NA   NA   <NA>
+      8   <span style='font-size:14px'><b>1_122</b></span><br> 1.0   NA   NA   <NA>
+      9   <span style='font-size:14px'><b>1_103</b></span><br> 1.0   NA   NA   <NA>
+      10  <span style='font-size:14px'><b>1_111</b></span><br> 1.0   NA   NA   <NA>
+      11  <span style='font-size:14px'><b>1_123</b></span><br> 1.0   NA   NA   <NA>
+      12  <span style='font-size:14px'><b>1_104</b></span><br> 1.0   NA   NA   <NA>
+      13  <span style='font-size:14px'><b>1_112</b></span><br> 1.0   NA   NA   <NA>
+      14  <span style='font-size:14px'><b>1_124</b></span><br> 1.0   NA   NA   <NA>
+      15  <span style='font-size:14px'><b>1_137</b></span><br> 1.0   NA   NA   <NA>
+      16  <span style='font-size:14px'><b>1_114</b></span><br> 1.0   NA   NA   <NA>
+      17  <span style='font-size:14px'><b>1_127</b></span><br> 1.0   NA   NA   <NA>
+      18  <span style='font-size:14px'><b>1_138</b></span><br> 1.0   NA   NA   <NA>
+      19  <span style='font-size:14px'><b>1_139</b></span><br> 1.0   NA   NA   <NA>
+      20  <span style='font-size:14px'><b>1_128</b></span><br> 1.0   NA   NA   <NA>
+      21  <span style='font-size:14px'><b>1_105</b></span><br> 1.0   NA   NA   <NA>
+      22  <span style='font-size:14px'><b>1_140</b></span><br> 1.0   NA   NA   <NA>
+      23  <span style='font-size:14px'><b>1_125</b></span><br> 1.0   NA   NA   <NA>
+      24  <span style='font-size:14px'><b>1_106</b></span><br> 1.0   NA   NA   <NA>
+      25  <span style='font-size:14px'><b>1_141</b></span><br> 1.0   NA   NA   <NA>
+      26  <span style='font-size:14px'><b>1_126</b></span><br> 1.0   NA   NA   <NA>
+      27  <span style='font-size:14px'><b>1_107</b></span><br> 1.0   NA   NA   <NA>
+      28  <span style='font-size:14px'><b>1_114</b></span><br> 1.0   NA   NA   <NA>
+      29  <span style='font-size:14px'><b>1_129</b></span><br> 1.0   NA   NA   <NA>
+      30  <span style='font-size:14px'><b>1_108</b></span><br> 1.0   NA   NA   <NA>
+      31  <span style='font-size:14px'><b>1_115</b></span><br> 1.0   NA   NA   <NA>
+      32  <span style='font-size:14px'><b>1_130</b></span><br> 1.0   NA   NA   <NA>
+      33  <span style='font-size:14px'><b>1_112</b></span><br> 1.0   NA   NA   <NA>
+      34  <span style='font-size:14px'><b>1_131</b></span><br> 1.0   NA   NA   <NA>
+      35  <span style='font-size:14px'><b>1_118</b></span><br> 1.0   NA   NA   <NA>
+      36  <span style='font-size:14px'><b>1_132</b></span><br> 1.0   NA   NA   <NA>
+      37  <span style='font-size:14px'><b>1_117</b></span><br> 1.0   NA   NA   <NA>
+      38  <span style='font-size:14px'><b>1_133</b></span><br> 1.0   NA   NA   <NA>
+      39  <span style='font-size:14px'><b>1_116</b></span><br> 1.0   NA   NA   <NA>
+      40  <span style='font-size:14px'><b>1_134</b></span><br> 1.0   NA   NA   <NA>
+      41  <span style='font-size:14px'><b>1_119</b></span><br> 1.0   NA   NA   <NA>
+      42  <span style='font-size:14px'><b>1_120</b></span><br> 1.0   NA   NA   <NA>
+      43  <span style='font-size:14px'><b>1_135</b></span><br>  NA  0.5  0.5   <NA>
+      44  <span style='font-size:14px'><b>1_101</b></span><br>  NA  0.5  0.5   <NA>
+      45  <span style='font-size:14px'><b>1_109</b></span><br>  NA  0.5  0.5   <NA>
+      46  <span style='font-size:14px'><b>1_121</b></span><br>  NA  0.5  0.5   <NA>
+      47  <span style='font-size:14px'><b>1_136</b></span><br>  NA  0.5  0.5   <NA>
+      48  <span style='font-size:14px'><b>1_102</b></span><br>  NA  0.5  0.5   <NA>
+      49  <span style='font-size:14px'><b>1_110</b></span><br>  NA  0.5  0.5   <NA>
+      50  <span style='font-size:14px'><b>1_122</b></span><br>  NA  0.5  0.5   <NA>
+      51  <span style='font-size:14px'><b>1_103</b></span><br>  NA  0.5  0.5   <NA>
+      52  <span style='font-size:14px'><b>1_111</b></span><br>  NA  0.5  0.5   <NA>
+      53  <span style='font-size:14px'><b>1_123</b></span><br>  NA  0.5  0.5   <NA>
+      54  <span style='font-size:14px'><b>1_104</b></span><br>  NA  0.5  0.5   <NA>
+      55  <span style='font-size:14px'><b>1_112</b></span><br>  NA  0.5  0.5   <NA>
+      56  <span style='font-size:14px'><b>1_124</b></span><br>  NA  0.5  0.5   <NA>
+      57  <span style='font-size:14px'><b>1_137</b></span><br>  NA  0.5  0.5   <NA>
+      58  <span style='font-size:14px'><b>1_114</b></span><br>  NA  0.5  0.5   <NA>
+      59  <span style='font-size:14px'><b>1_127</b></span><br>  NA  0.5  0.5   <NA>
+      60  <span style='font-size:14px'><b>1_138</b></span><br>  NA  0.5  0.5   <NA>
+      61  <span style='font-size:14px'><b>1_139</b></span><br>  NA  0.5  0.5   <NA>
+      62  <span style='font-size:14px'><b>1_128</b></span><br>  NA  0.5  0.5   <NA>
+      63  <span style='font-size:14px'><b>1_105</b></span><br>  NA  0.5  0.5   <NA>
+      64  <span style='font-size:14px'><b>1_140</b></span><br>  NA  0.5  0.5   <NA>
+      65  <span style='font-size:14px'><b>1_125</b></span><br>  NA  0.5  0.5   <NA>
+      66  <span style='font-size:14px'><b>1_106</b></span><br>  NA  0.5  0.5   <NA>
+      67  <span style='font-size:14px'><b>1_141</b></span><br>  NA  0.5  0.5   <NA>
+      68  <span style='font-size:14px'><b>1_126</b></span><br>  NA  0.5  0.5   <NA>
+      69  <span style='font-size:14px'><b>1_107</b></span><br>  NA  0.5  0.5   <NA>
+      70  <span style='font-size:14px'><b>1_114</b></span><br>  NA  0.5  0.5   <NA>
+      71  <span style='font-size:14px'><b>1_129</b></span><br>  NA  0.5  0.5   <NA>
+      72  <span style='font-size:14px'><b>1_108</b></span><br>  NA  0.5  0.5   <NA>
+      73  <span style='font-size:14px'><b>1_115</b></span><br>  NA  0.5  0.5   <NA>
+      74  <span style='font-size:14px'><b>1_130</b></span><br>  NA  0.5  0.5   <NA>
+      75  <span style='font-size:14px'><b>1_112</b></span><br>  NA  0.5  0.5   <NA>
+      76  <span style='font-size:14px'><b>1_131</b></span><br>  NA  0.5  0.5   <NA>
+      77  <span style='font-size:14px'><b>1_118</b></span><br>  NA  0.5  0.5   <NA>
+      78  <span style='font-size:14px'><b>1_132</b></span><br>  NA  0.5  0.5   <NA>
+      79  <span style='font-size:14px'><b>1_117</b></span><br>  NA  0.5  0.5   <NA>
+      80  <span style='font-size:14px'><b>1_133</b></span><br>  NA  0.5  0.5   <NA>
+      81  <span style='font-size:14px'><b>1_116</b></span><br>  NA  0.5  0.5   <NA>
+      82  <span style='font-size:14px'><b>1_134</b></span><br>  NA  0.5  0.5   <NA>
+      83  <span style='font-size:14px'><b>1_119</b></span><br>  NA  0.5  0.5   <NA>
+      84  <span style='font-size:14px'><b>1_120</b></span><br>  NA  0.5  0.5   <NA>
+      85                                                  <NA> 1.0   NA   NA  solid
+      86                                                  <NA> 1.0   NA   NA  solid
+      87                                                  <NA> 1.0   NA   NA  solid
+      88                                                  <NA> 1.0   NA   NA  solid
+      89                                                  <NA> 1.0   NA   NA  solid
+      90                                                  <NA> 1.0   NA   NA  solid
+      91                                                  <NA> 1.0   NA   NA  solid
+      92                                                  <NA>  NA  0.5  1.0   <NA>
+      93                                                  <NA> 1.0   NA   NA  solid
+      94                                                  <NA> 1.0   NA   NA  solid
+      95                                                  <NA> 1.0   NA   NA  solid
+      96                                                  <NA> 1.0   NA   NA  solid
+      97                                                  <NA>  NA  0.5  0.5   <NA>
+      98                                                  <NA>  NA  0.5  0.5   <NA>
+      99                                                  <NA>  NA  0.5  0.5   <NA>
+      100                                                 <NA> 1.0   NA   NA  solid
+      101                                                 <NA> 1.0   NA   NA  solid
+      102                                                 <NA> 1.0   NA   NA  solid
+      103                                                 <NA> 1.0   NA   NA  solid
+      104                                                 <NA> 1.0   NA   NA  solid
+      105                                                 <NA>  NA  0.5  0.5   <NA>
+      106                                                 <NA>  NA  0.5  0.5   <NA>
+      107                                                 <NA>  NA  0.5  0.5   <NA>
+      108                                                 <NA>  NA   NA   NA   <NA>
+      109                                                 <NA>  NA   NA   NA   <NA>
+      110                                                 <NA> 2.5   NA   NA  solid
+      111                                                 <NA> 2.5   NA   NA  solid
+      112                                                 <NA> 1.0   NA   NA  solid
+      113                                                 <NA> 1.0   NA   NA  solid
+      114                                                 <NA> 1.0   NA   NA  solid
+      115                                                 <NA> 1.0   NA   NA  solid
+      116                                                 <NA> 1.0   NA   NA  solid
+      117                                                 <NA> 1.0   NA   NA  solid
+      118                                                 <NA> 1.0   NA   NA  solid
+      119                                                 <NA> 1.0   NA   NA  solid
+      120                                                 <NA> 1.0   NA   NA  solid
+      121                                                 <NA> 1.0   NA   NA  solid
+      122                                                 <NA> 1.0   NA   NA  solid
+      123                                                 <NA> 1.0   NA   NA  solid
+      124 <span style='font-size:14px'><b>1_135</b></span><br>  NA  0.5  1.0   <NA>
+      125 <span style='font-size:14px'><b>1_101</b></span><br>  NA  0.5  1.0   <NA>
+      126 <span style='font-size:14px'><b>1_109</b></span><br>  NA  0.5  1.0   <NA>
+      127 <span style='font-size:14px'><b>1_121</b></span><br>  NA  0.5  1.0   <NA>
+      128 <span style='font-size:14px'><b>1_136</b></span><br>  NA  0.5  1.0   <NA>
+      129 <span style='font-size:14px'><b>1_102</b></span><br>  NA  0.5  1.0   <NA>
+      130 <span style='font-size:14px'><b>1_110</b></span><br>  NA  0.5  1.0   <NA>
+      131 <span style='font-size:14px'><b>1_122</b></span><br>  NA  0.5  1.0   <NA>
+      132 <span style='font-size:14px'><b>1_103</b></span><br>  NA  0.5  1.0   <NA>
+      133 <span style='font-size:14px'><b>1_111</b></span><br>  NA  0.5  1.0   <NA>
+      134 <span style='font-size:14px'><b>1_123</b></span><br>  NA  0.5  1.0   <NA>
+      135 <span style='font-size:14px'><b>1_104</b></span><br>  NA  0.5  1.0   <NA>
+      136 <span style='font-size:14px'><b>1_112</b></span><br>  NA  0.5  1.0   <NA>
+      137 <span style='font-size:14px'><b>1_124</b></span><br>  NA  0.5  1.0   <NA>
+      138 <span style='font-size:14px'><b>1_137</b></span><br>  NA  0.5  1.0   <NA>
+      139 <span style='font-size:14px'><b>1_114</b></span><br>  NA  0.5  1.0   <NA>
+      140 <span style='font-size:14px'><b>1_127</b></span><br>  NA  0.5  1.0   <NA>
+      141 <span style='font-size:14px'><b>1_138</b></span><br>  NA  0.5  1.0   <NA>
+      142 <span style='font-size:14px'><b>1_139</b></span><br>  NA  0.5  1.0   <NA>
+      143 <span style='font-size:14px'><b>1_128</b></span><br>  NA  0.5  1.0   <NA>
+      144 <span style='font-size:14px'><b>1_105</b></span><br>  NA  0.5  1.0   <NA>
+      145 <span style='font-size:14px'><b>1_140</b></span><br>  NA  0.5  1.0   <NA>
+      146 <span style='font-size:14px'><b>1_125</b></span><br>  NA  0.5  1.0   <NA>
+      147 <span style='font-size:14px'><b>1_106</b></span><br>  NA  0.5  1.0   <NA>
+      148 <span style='font-size:14px'><b>1_141</b></span><br>  NA  0.5  1.0   <NA>
+      149 <span style='font-size:14px'><b>1_126</b></span><br>  NA  0.5  1.0   <NA>
+      150 <span style='font-size:14px'><b>1_107</b></span><br>  NA  0.5  1.0   <NA>
+      151 <span style='font-size:14px'><b>1_114</b></span><br>  NA  0.5  1.0   <NA>
+      152 <span style='font-size:14px'><b>1_129</b></span><br>  NA  0.5  1.0   <NA>
+      153 <span style='font-size:14px'><b>1_108</b></span><br>  NA  0.5  1.0   <NA>
+      154 <span style='font-size:14px'><b>1_115</b></span><br>  NA  0.5  1.0   <NA>
+      155 <span style='font-size:14px'><b>1_130</b></span><br>  NA  0.5  1.0   <NA>
+      156 <span style='font-size:14px'><b>1_112</b></span><br>  NA  0.5  1.0   <NA>
+      157 <span style='font-size:14px'><b>1_131</b></span><br>  NA  0.5  1.0   <NA>
+      158 <span style='font-size:14px'><b>1_118</b></span><br>  NA  0.5  1.0   <NA>
+      159 <span style='font-size:14px'><b>1_132</b></span><br>  NA  0.5  1.0   <NA>
+      160 <span style='font-size:14px'><b>1_117</b></span><br>  NA  0.5  1.0   <NA>
+      161 <span style='font-size:14px'><b>1_133</b></span><br>  NA  0.5  1.0   <NA>
+      162 <span style='font-size:14px'><b>1_116</b></span><br>  NA  0.5  1.0   <NA>
+      163 <span style='font-size:14px'><b>1_134</b></span><br>  NA  0.5  1.0   <NA>
+      164 <span style='font-size:14px'><b>1_119</b></span><br>  NA  0.5  1.0   <NA>
+      165 <span style='font-size:14px'><b>1_120</b></span><br>  NA  0.5  1.0   <NA>
+      166 <span style='font-size:14px'><b>1_135</b></span><br>  NA  0.5  1.0   <NA>
+      167 <span style='font-size:14px'><b>1_101</b></span><br>  NA  0.5  1.0   <NA>
+      168 <span style='font-size:14px'><b>1_136</b></span><br>  NA  0.5  1.0   <NA>
+      169 <span style='font-size:14px'><b>1_102</b></span><br>  NA  0.5  1.0   <NA>
+      170 <span style='font-size:14px'><b>1_103</b></span><br>  NA  0.5  1.0   <NA>
+      171 <span style='font-size:14px'><b>1_112</b></span><br>  NA  0.5  1.0   <NA>
+      172 <span style='font-size:14px'><b>1_124</b></span><br>  NA  0.5  1.0   <NA>
+      173 <span style='font-size:14px'><b>1_114</b></span><br>  NA  0.5  1.0   <NA>
+      174 <span style='font-size:14px'><b>1_114</b></span><br>  NA  0.5  1.0   <NA>
+      175 <span style='font-size:14px'><b>1_112</b></span><br>  NA  0.5  1.0   <NA>
+      176 <span style='font-size:14px'><b>1_134</b></span><br>  NA  0.5  1.0   <NA>
+      177                                                 <NA> 1.0   NA   NA  solid
+      178                                                 <NA> 1.0   NA   NA  solid
+      179                                                 <NA> 1.0   NA   NA  solid
+      180                                                 <NA> 1.0   NA   NA  solid
+      181                                                 <NA> 1.0   NA   NA  solid
+      182                                                 <NA> 1.0   NA   NA  solid
+      183                                                 <NA> 1.0   NA   NA  solid
+      184                                                 <NA> 1.0   NA   NA  solid
+      185                                                 <NA> 1.0   NA   NA  solid
+      186                                                 <NA> 1.0   NA   NA  solid
+      187                                                 <NA> 1.0   NA   NA  solid
+      188                                                 <NA> 1.0   NA   NA  solid
+      189                                                 <NA> 1.0   NA   NA  solid
+      190                                                 <NA> 1.0   NA   NA  solid
+      191                                                 <NA> 1.0   NA   NA  solid
+      192                                                 <NA> 1.0   NA   NA  solid
+      193                                                 <NA> 1.0   NA   NA  solid
+      194                                                 <NA> 1.0   NA   NA  solid
+      195                                                 <NA> 1.0   NA   NA  solid
+      196                                                 <NA> 1.0   NA   NA  solid
+      197                                                 <NA> 1.0   NA   NA  solid
+      198                                                 <NA> 1.0   NA   NA  solid
+      199                                                 <NA> 1.0   NA   NA  solid
+      200                                                 <NA> 1.0   NA   NA  solid
+      201                                                 <NA> 1.0   NA   NA  solid
+      202                                                 <NA> 1.0   NA   NA  solid
+      203                                                 <NA> 1.0   NA   NA  solid
+      204                                                 <NA> 1.0   NA   NA  solid
+      205                                                 <NA> 1.0   NA   NA  solid
+      206                                                 <NA> 1.0   NA   NA  solid
+      207                                                 <NA> 1.0   NA   NA  solid
+      208                                                 <NA> 1.0   NA   NA  solid
+      209                                                 <NA> 1.0   NA   NA  solid
+      210                                                 <NA> 1.0   NA   NA  solid
+      211                                                 <NA> 1.0   NA   NA  solid
+      212                                                 <NA> 1.0   NA   NA  solid
+      213                                                 <NA> 1.0   NA   NA  solid
+      214                                                 <NA> 1.0   NA   NA  solid
+      215                                                 <NA> 1.0   NA   NA  solid
+      216                                                 <NA> 1.0   NA   NA  solid
+      217                                                 <NA> 1.0   NA   NA  solid
+      218                                                 <NA> 1.0   NA   NA  solid
+      219                                                 <NA> 1.0   NA   NA  solid
+      220                                                 <NA> 1.0   NA   NA  solid
+      221                                                 <NA> 1.0   NA   NA  solid
+      222                                                 <NA> 1.0   NA   NA  solid
+      223                                                 <NA> 1.0   NA   NA  solid
+      224                                                 <NA> 1.0   NA   NA  solid
+      225                                                 <NA> 1.0   NA   NA  solid
+      226                                                 <NA> 1.0   NA   NA  solid
+      227                                                 <NA> 1.0   NA   NA  solid
+      228                                                 <NA> 1.0   NA   NA  solid
+      229                                                 <NA> 1.0   NA   NA  solid
+      230                                                 <NA> 1.0   NA   NA  solid
+      231                                                 <NA> 1.0   NA   NA  solid
+      232                                                 <NA> 1.0   NA   NA  solid
+      233                                                 <NA> 1.0   NA   NA  solid
+      234                                                 <NA> 1.0   NA   NA  solid
+      235                                                 <NA> 1.0   NA   NA  solid
+      236                                                 <NA> 1.0   NA   NA  solid
+      237                                                 <NA> 1.0   NA   NA  solid
+      238                                                 <NA> 1.0   NA   NA  solid
+      239                                                 <NA> 1.0   NA   NA  solid
+      240                                                 <NA> 1.0   NA   NA  solid
+      241                                                 <NA> 1.0   NA   NA  solid
+      242                                                 <NA> 1.0   NA   NA  solid
+      243                                                 <NA> 1.0   NA   NA  solid
+      244                                                 <NA> 1.0   NA   NA  solid
+      245                                                 <NA> 1.0   NA   NA  solid
+      246                                                 <NA> 1.0   NA   NA  solid
+      247                                                 <NA> 1.0   NA   NA  solid
+      248                                                 <NA> 1.0   NA   NA  solid
+      249                                                 <NA> 1.0   NA   NA  solid
+      250                                                 <NA> 1.0   NA   NA  solid
+      251                                                 <NA> 1.0   NA   NA  solid
+      252                                                 <NA> 1.0   NA   NA  solid
+      253                                                 <NA> 1.0   NA   NA  solid
+      254                                                 <NA> 1.0   NA   NA  solid
+      255                                                 <NA> 1.0   NA   NA  solid
+      256                                                 <NA> 1.0   NA   NA  solid
+      257                                                 <NA> 1.0   NA   NA  solid
+      258                                                 <NA> 1.0   NA   NA  solid
+      259                                                 <NA> 1.0   NA   NA  solid
+      260                                                 <NA> 1.0   NA   NA  solid
+      261                                                 <NA> 1.0   NA   NA dashed
+      262                                                 <NA> 1.0   NA   NA dashed
           pch
       1    NA
       2    NA

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -242,3 +242,37 @@ test_that("Pedigree plot with different label distances & label cex", {
         }
     )
 })
+
+test_that("Pedigree ggplot with legend", {
+    data(sampleped)
+    pedi <- Pedigree(sampleped)
+    pedi1 <- pedi[famid(ped(pedi)) == "1"]
+
+    plot_lst <- plot_legend(pedi1, ggplot_gen = TRUE, add_to_existing = FALSE)
+    plot_lst$ggplot
+    vdiffr::expect_doppelganger("Ped with legend default",
+        function() {
+            plot_lst$ggplot
+        }
+    )
+
+    vdiffr::expect_doppelganger("Ped with legend custom",
+        function() {
+            plot(
+                pedi1, legend = TRUE,
+                leg_cex = 0.5, leg_symbolsize = 0.3,
+                leg_loc = c(0, 2, 0, 2),
+                leg_adjx = 0.2, leg_adjy = -0.2
+            )
+        }
+    )
+
+    vdiffr::expect_doppelganger("Ped with legend ggplot",
+        function() {
+            plot(
+                pedi1, legend = TRUE,
+                ggplot_gen = TRUE
+            )$ggplot
+        }
+    )
+})

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -248,31 +248,19 @@ test_that("Pedigree ggplot with legend", {
     pedi <- Pedigree(sampleped)
     pedi1 <- pedi[famid(ped(pedi)) == "1"]
 
-    plot_lst <- plot_legend(pedi1, ggplot_gen = TRUE, add_to_existing = FALSE)
-    plot_lst$ggplot
-    vdiffr::expect_doppelganger("Ped with legend default",
-        function() {
-            plot_lst$ggplot
-        }
-    )
-
-    vdiffr::expect_doppelganger("Ped with legend custom",
-        function() {
-            plot(
-                pedi1, legend = TRUE,
-                leg_cex = 0.5, leg_symbolsize = 0.3,
-                leg_loc = c(0, 2, 0, 2),
-                leg_adjx = 0.2, leg_adjy = -0.2
-            )
-        }
+    plot_lst <- plot(
+        pedi1, ggplot_gen = TRUE, legend = TRUE,
+        leg_cex = 0.8, leg_symbolsize = 0.1,
     )
 
     vdiffr::expect_doppelganger("Ped with legend ggplot",
         function() {
-            plot(
-                pedi1, legend = TRUE,
-                ggplot_gen = TRUE
-            )$ggplot
+            cowplot::plot_grid(
+                plot_lst$ggplot,
+                plot_lst$legend$ggplot +
+                    ggplot2::xlim(-2, 20),
+                ncol = 1, nrow = 2, rel_heights = c(4, 1)
+            )
         }
     )
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -244,6 +244,8 @@ test_that("Pedigree plot with different label distances & label cex", {
 })
 
 test_that("Pedigree ggplot with legend", {
+    testthat::skip_if_not_installed("cowplot")
+
     data(sampleped)
     pedi <- Pedigree(sampleped)
     pedi1 <- pedi[famid(ped(pedi)) == "1"]

--- a/vignettes/Pedixplorer.Rmd
+++ b/vignettes/Pedixplorer.Rmd
@@ -536,6 +536,28 @@ plot(
 )
 ```
 
+## Legend with ggplot2
+
+The legend can be added to the plot with the `legend` argument set to
+`TRUE`. However the legend will be generated as a separate ggplot object.
+To combine the legend and the pedigree plot, you can use the
+`cowplot::plot_grid()` function as shown below.
+
+```
+{r, legend_ggplot2, fig.alt = "Pedigree with legend"}
+library(cowplot)
+plot_lst <- plot(
+    pedi1, ggplot_gen = TRUE, legend = TRUE,
+    leg_cex = 0.8, leg_symbolsize = 0.1,
+)
+cowplot::plot_grid(
+    plot_lst$ggplot,
+    plot_lst$legend$ggplot +
+        ggplot2::xlim(-2, 20),
+    ncol = 1, nrow = 2, rel_heights = c(4, 1)
+)
+```
+
 
 ## Render interactive
 


### PR DESCRIPTION
Legend was not working with ggpplot.

The legend is now added as a separated ggplot object that you can plot with the pedigree plot using `cowplot::plot_grid()`.

An example is added to the main vignette.